### PR TITLE
Don't ignore generated regs in Z

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,3 @@ bower_components/
 .grunt/
 src/vendor/
 dist/
-
-# ignore generated regulations in Z
-regulation/1026/*


### PR DESCRIPTION
This reverts part of [this commit](https://github.com/cfpb/regulations-xml/commit/9f2b40a472f608bd11cbd3b4fad7a45d6ae2a96a) which inadvertently added `regulations/1026` to `.gitignore`.