### PR TITLE
Use Travis CI for RegML validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,6 @@ script:
   - git clone https://github.com/cfpb/regulations-xml-parser.git
   - git clone https://github.com/cfpb/regulations-schema.git
   - pip install -r regulations-xml-parser/requirements.txt
+  - echo "XSD_FILE = 'regulations-schema/src/eregs.xsd'" >> regulations-xml-parser/local_settings.py
   - export GIT_COMMITS=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_COMMIT_RANGE; else echo $TRAVIS_BRANCH; fi)
   - REGML_PY=regulations-xml-parser/regml.py GIT_COMMITS=$GIT_COMMITS ./validate_xml.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 
-script: 
+script:
   - git clone https://github.com/cfpb/regulations-xml-parser.git
   - git clone https://github.com/cfpb/regulations-schema.git
   - pip install -r regulations-xml-parser/requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: python
+
+script: 
+  - git clone https://github.com/cfpb/regulations-xml-parser.git
+  - git clone https://github.com/cfpb/regulations-schema.git
+  - pip install -r regulations-xml-parser/requirements.txt
+  - export GIT_COMMITS=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_COMMIT_RANGE; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
+  - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH, PR=$PR, GIT_COMMITS=$GIT_COMMITS"
+  - REGML_PY=regulations-xml-parser/regml.py GIT_COMMITS=$GIT_COMMITS ./validate_xml.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,5 @@ script:
   - git clone https://github.com/cfpb/regulations-xml-parser.git
   - git clone https://github.com/cfpb/regulations-schema.git
   - pip install -r regulations-xml-parser/requirements.txt
-  - export GIT_COMMITS=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_COMMIT_RANGE; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
-  - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH, PR=$PR, GIT_COMMITS=$GIT_COMMITS"
+  - export GIT_COMMITS=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_COMMIT_RANGE; else echo $TRAVIS_BRANCH; fi)
   - REGML_PY=regulations-xml-parser/regml.py GIT_COMMITS=$GIT_COMMITS ./validate_xml.sh

--- a/notice/1013/2016-28710.xml
+++ b/notice/1013/2016-28710.xml
@@ -9,6 +9,15 @@
     <title>CONSUMER LEASING</title>
   </fdsys>
   <preamble>
+    <agency>Bureau of Consumer Financial Protection</agency>
+    <regLetter>M</regLetter>
+    <cfr>
+      <title>12</title>
+      <section>1013</section>
+    </cfr>
+    <documentNumber>2016-28710</documentNumber>
+    <effectiveDate>2017-01-01</effectiveDate>
+    <federalRegisterURL>https://www.federalregister.gov/documents/2016/11/30/2016-28710/consumer-leasing-regulation-m</federalRegisterURL>
   </preamble>
   <changeset leftDocumentNumber="2015-30071" rightDocumentNumber="2016-28710">
 

--- a/notice/1013/2016-28710.xml
+++ b/notice/1013/2016-28710.xml
@@ -9,15 +9,6 @@
     <title>CONSUMER LEASING</title>
   </fdsys>
   <preamble>
-    <agency>Bureau of Consumer Financial Protection</agency>
-    <regLetter>M</regLetter>
-    <cfr>
-      <title>12</title>
-      <section>1013</section>
-    </cfr>
-    <documentNumber>2016-28710</documentNumber>
-    <effectiveDate>2017-01-01</effectiveDate>
-    <federalRegisterURL>https://www.federalregister.gov/documents/2016/11/30/2016-28710/consumer-leasing-regulation-m</federalRegisterURL>
   </preamble>
   <changeset leftDocumentNumber="2015-30071" rightDocumentNumber="2016-28710">
 

--- a/validate_xml.sh
+++ b/validate_xml.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+GIT_COMMITS=${GIT_COMMITS:-master}
+REGML_PY=${REGML_PY:-regml.py}
+
+# Fail if this command fails.
+set -e
+echo Using git commit range $GIT_COMMITS
+files=`git diff --name-only --diff-filter=AM $GIT_COMMITS`
+set +e
+
+errcode=0
+
+while read -r f; do
+    # Skip empty lines.
+    [[ -z "$f" ]] && continue
+
+    # Skip lines that don't match regulation/*.xml or notice/*.xml.
+    if ! [[ "$f" =~ ^(regulation|notice)/.*\.xml ]]; then
+        echo Skipping "$f"
+        continue
+    fi
+
+    echo Validating "$f"
+    "$REGML_PY" validate "$f"
+    errcode=$(($errcode | $?))
+done <<< "$files"
+
+exit $errcode


### PR DESCRIPTION
This PR adds a `.travis.yml` file to configure [automated TravisCI builds](https://travis-ci.org/cfpb/regulations-xml) that run RegML validation against any new or changed RegML files.

For Pull Request checks, this should check the current state of the PR branch against the originating branch (`master`). For Push checks, it should only check the most recent push.

This commit should fail checks because of a purposefully modified RegML file. The changes to `notice/1013/2016-28710.xml` should need to be reverted to pass and merge this PR.