### PR TITLE
Don't dump RegML validator output to console

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,8 @@ script:
   - git clone https://github.com/cfpb/regulations-schema.git
   - pip install -r regulations-xml-parser/requirements.txt
   - echo "XSD_FILE = 'regulations-schema/src/eregs.xsd'" >> regulations-xml-parser/local_settings.py
+  - echo "TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST"
+  - echo "TRAVIS_COMMIT_RANGE=$TRAVIS_COMMIT_RANGE"
+  - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH"
   - export GIT_COMMITS=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_COMMIT_RANGE; else echo $TRAVIS_BRANCH; fi)
   - REGML_PY=regulations-xml-parser/regml.py GIT_COMMITS=$GIT_COMMITS ./validate_xml.sh

--- a/validate_xml.sh
+++ b/validate_xml.sh
@@ -22,8 +22,16 @@ while read -r f; do
     fi
 
     echo Validating "$f"
-    "$REGML_PY" validate "$f"
-    errcode=$(($errcode | $?))
+    "$REGML_PY" validate "$f" > /dev/null
+    file_errcode="$?"
+
+    if [[ "$file_errcode" == "0" ]]; then
+        echo "Validated successfully."
+    else
+        echo "Validation failed!"
+    fi
+
+    errcode=$(($errcode | $file_errcode))
 done <<< "$files"
 
 exit $errcode


### PR DESCRIPTION
The `validate.xml.sh` script can be used to validate RegML, and is run as part of the automated Travis build. For large diffs, the validator can generate many, many warnings, which exceeds the maximum Travis build log size. This can trigger Travis failures incorrectly.

This change modifies the script so that validation output is piped to `/dev/null`. Each file is still validated, and validation success/failure messages are printed, allowing RegML editors to
check/correct problems offline.

This PR is a followup to #24.