### PR TITLE
Fix Travis logic on first commit in a PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,5 @@ script:
   - echo "TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST"
   - echo "TRAVIS_COMMIT_RANGE=$TRAVIS_COMMIT_RANGE"
   - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH"
-  - export GIT_COMMITS=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_COMMIT_RANGE; else echo $TRAVIS_BRANCH; fi)
-  - REGML_PY=regulations-xml-parser/regml.py GIT_COMMITS=$GIT_COMMITS ./validate_xml.sh
+  - export GIT_COMMITS="$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo ${TRAVIS_COMMIT_RANGE:-HEAD~1 HEAD}; else echo $TRAVIS_BRANCH; fi)"
+  - REGML_PY=regulations-xml-parser/regml.py ./validate_xml.sh

--- a/README.md
+++ b/README.md
@@ -9,4 +9,3 @@ to generate JSON for
 [regulations-core](https://github.com/cfpb/regulations-core)
 to serve to [regulations-site](https://github.com/cfpb/regulations-site).
 
-Test change to README to test Travis check logic.

--- a/README.md
+++ b/README.md
@@ -9,3 +9,4 @@ to generate JSON for
 [regulations-core](https://github.com/cfpb/regulations-core)
 to serve to [regulations-site](https://github.com/cfpb/regulations-site).
 
+Test change to README to test Travis check logic.


### PR DESCRIPTION
The automatic RegML validation that runs against PRs seems to have a problem running against the first commit in the PR. This because the `TRAVIS_COMMIT_RANGE` environment variable set by Travis doesn't get set on the first commit of a PR. Instead we can possibly use `HEAD~1 HEAD` to refer to the previous commit.