### PR TITLE
Add notice and updated Reg M for 2017-24411

### DIFF
--- a/notice/1013/2017-24411.xml
+++ b/notice/1013/2017-24411.xml
@@ -1,0 +1,32 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<notice xmlns="eregs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="eregs https://raw.githubusercontent.com/cfpb/regulations-schema/master/src/eregs.xsd">
+  <fdsys>
+    <cfrTitleNum>12</cfrTitleNum>
+    <cfrTitleText>Banks and Banking</cfrTitleText>
+    <volume>8</volume>
+    <date>2017-11-09</date>
+    <originalDate>2012-01-01</originalDate>
+    <title>CONSUMER LEASING</title>
+  </fdsys>
+  <preamble>
+    <agency>Bureau of Consumer Financial Protection</agency>
+    <regLetter>M</regLetter>
+    <cfr>
+      <title>12</title>
+      <section>1013</section>
+    </cfr>
+    <documentNumber>2017-24411</documentNumber>
+    <effectiveDate>2018-01-01</effectiveDate>
+    <federalRegisterURL>https://www.federalregister.gov/documents/2017/11/09/2017-24411/consumer-leasing-regulation-m</federalRegisterURL>
+  </preamble>
+  <changeset leftDocumentNumber="2016-28710" rightDocumentNumber="2017-24411">
+
+    <!-- In supplement I to part 1013, under Section 1013.2—Definitions, -->
+    <!-- under 2(e)—Consumer Lease, paragraph 11 is revised, -->
+    <change operation="added" label="1013-2-e-Interp-11-ix" parent="1013-2-e-Interp-11" after="1013-2-e-Interp-11-viii">
+      <interpParagraph label="1013-2-e-Interp-11-ix" marker="ix.">
+        <content>From January 1, 2018 through December 31, 2018, the threshold amount is $55,800.</content>
+      </interpParagraph>
+    </change>
+  </changeset>
+</notice>

--- a/regulation/1013/2017-24411.xml
+++ b/regulation/1013/2017-24411.xml
@@ -1,0 +1,1767 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<regulation xmlns="eregs" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="eregs https://raw.githubusercontent.com/cfpb/regulations-schema/master/src/eregs.xsd">
+  <fdsys>
+    <cfrTitleNum>12</cfrTitleNum>
+    <cfrTitleText>Banks and Banking</cfrTitleText>
+    <volume>8</volume>
+    <date>2017-11-09</date>
+    <originalDate>2012-01-01</originalDate>
+    <title>CONSUMER LEASING</title>
+  </fdsys>
+  <preamble>
+    <agency>Bureau of Consumer Financial Protection</agency>
+    <regLetter>M</regLetter>
+    <cfr>
+      <title>12</title>
+      <section>1013</section>
+    </cfr>
+    <documentNumber>2017-24411</documentNumber>
+    <effectiveDate>2018-01-01</effectiveDate>
+    <federalRegisterURL>https://www.federalregister.gov/documents/2017/11/09/2017-24411/consumer-leasing-regulation-m</federalRegisterURL>
+  </preamble>
+  <part label="1013">
+    <tableOfContents>
+      <tocSecEntry target="1013-1">
+        <sectionNum>1</sectionNum>
+        <sectionSubject>§ 1013.1 Authority, scope, purpose, and enforcement.</sectionSubject>
+      </tocSecEntry>
+      <tocSecEntry target="1013-2">
+        <sectionNum>2</sectionNum>
+        <sectionSubject>§ 1013.2 Definitions.</sectionSubject>
+      </tocSecEntry>
+      <tocSecEntry target="1013-3">
+        <sectionNum>3</sectionNum>
+        <sectionSubject>§ 1013.3 General disclosure requirements.</sectionSubject>
+      </tocSecEntry>
+      <tocSecEntry target="1013-4">
+        <sectionNum>4</sectionNum>
+        <sectionSubject>§ 1013.4 Content of disclosures.</sectionSubject>
+      </tocSecEntry>
+      <tocSecEntry target="1013-5">
+        <sectionNum>5</sectionNum>
+        <sectionSubject>§ 1013.5 Renegotiations, extensions, and assumptions.</sectionSubject>
+      </tocSecEntry>
+      <tocSecEntry target="1013-6">
+        <sectionNum>6</sectionNum>
+        <sectionSubject>§ 1013.6 [Reserved]</sectionSubject>
+      </tocSecEntry>
+      <tocSecEntry target="1013-7">
+        <sectionNum>7</sectionNum>
+        <sectionSubject>§ 1013.7 Advertising.</sectionSubject>
+      </tocSecEntry>
+      <tocSecEntry target="1013-8">
+        <sectionNum>8</sectionNum>
+        <sectionSubject>§ 1013.8 Record retention.</sectionSubject>
+      </tocSecEntry>
+      <tocSecEntry target="1013-9">
+        <sectionNum>9</sectionNum>
+        <sectionSubject>§ 1013.9 Relation to state laws.</sectionSubject>
+      </tocSecEntry>
+      <tocAppEntry target="1013-A">
+        <appendixLetter>A</appendixLetter>
+        <appendixSubject>Appendix A to Part 1013—Model Forms</appendixSubject>
+      </tocAppEntry>
+      <tocAppEntry target="1013-B">
+        <appendixLetter>B</appendixLetter>
+        <appendixSubject>Appendix B to Part 1013 [Reserved]</appendixSubject>
+      </tocAppEntry>
+      <tocAppEntry target="1013-C">
+        <appendixLetter>C</appendixLetter>
+        <appendixSubject>Appendix C to Part 1013—Issuance of Official Interpretations</appendixSubject>
+      </tocAppEntry>
+      <tocAppEntry target="1013-Interp">
+        <appendixLetter>Interp</appendixLetter>
+        <appendixSubject>Supplement I to Part 1013—Official Interpretations</appendixSubject>
+      </tocAppEntry>
+    </tableOfContents>
+    <content>
+      <subpart label="1013-Subpart">
+        <tableOfContents label="1013-Subpart-TOC">
+          <tocSecEntry target="1013-1">
+            <sectionNum>1</sectionNum>
+            <sectionSubject>§ 1013.1 Authority, scope, purpose, and enforcement.</sectionSubject>
+          </tocSecEntry>
+          <tocSecEntry target="1013-2">
+            <sectionNum>2</sectionNum>
+            <sectionSubject>§ 1013.2 Definitions.</sectionSubject>
+          </tocSecEntry>
+          <tocSecEntry target="1013-3">
+            <sectionNum>3</sectionNum>
+            <sectionSubject>§ 1013.3 General disclosure requirements.</sectionSubject>
+          </tocSecEntry>
+          <tocSecEntry target="1013-4">
+            <sectionNum>4</sectionNum>
+            <sectionSubject>§ 1013.4 Content of disclosures.</sectionSubject>
+          </tocSecEntry>
+          <tocSecEntry target="1013-5">
+            <sectionNum>5</sectionNum>
+            <sectionSubject>§ 1013.5 Renegotiations, extensions, and assumptions.</sectionSubject>
+          </tocSecEntry>
+          <tocSecEntry target="1013-6">
+            <sectionNum>6</sectionNum>
+            <sectionSubject>§ 1013.6 [Reserved]</sectionSubject>
+          </tocSecEntry>
+          <tocSecEntry target="1013-7">
+            <sectionNum>7</sectionNum>
+            <sectionSubject>§ 1013.7 Advertising.</sectionSubject>
+          </tocSecEntry>
+          <tocSecEntry target="1013-8">
+            <sectionNum>8</sectionNum>
+            <sectionSubject>§ 1013.8 Record retention.</sectionSubject>
+          </tocSecEntry>
+          <tocSecEntry target="1013-9">
+            <sectionNum>9</sectionNum>
+            <sectionSubject>§ 1013.9 Relation to state laws.</sectionSubject>
+          </tocSecEntry>
+        </tableOfContents>
+        <content>
+          <section label="1013-1" sectionNum="1">
+            <subject>§ 1013.1 Authority, scope, purpose, and enforcement.</subject>
+            <paragraph label="1013-1-a" marker="(a)">
+              <title type="keyterm">Authority.</title>
+              <content>The regulation in this part, known as Regulation M, is issued by the Bureau of Consumer Financial Protection to implement the consumer leasing provisions of the Truth in Lending Act, which is Title I of the Consumer Credit Protection Act, as amended (<ref target="USC:15-1601" reftype="external">15 U.S.C. 1601</ref> et seq.). Information collection requirements contained in this part have been approved by the Office of Management and Budget under the provisions of <ref target="USC:44-3501" reftype="external">44 U.S.C. 3501</ref> et seq. and have been assigned OMB control number 3170-0006.</content>
+            </paragraph>
+            <paragraph label="1013-1-b" marker="(b)">
+              <title type="keyterm">Scope and purpose.</title>
+              <content>This part applies to all <ref target="1013-2-k" reftype="term">persons</ref> that are <ref target="1013-2-h" reftype="term">lessors</ref> of <ref target="1013-2-l" reftype="term">personal property</ref> under <ref target="1013-2-e-1" reftype="term">consumer leases</ref> as those terms are defined in § <ref target="1013-2-e-1" reftype="internal">1013.2(e)(1)</ref> and <ref target="1013-2-h" reftype="internal">(h)</ref>, except <ref target="1013-2-k" reftype="term">persons</ref> excluded from coverage of this part by section 1029 of the Consumer Financial Protection Act of 2010, Title X of the Dodd-Frank Wall Street Reform and Consumer Protection Act (Dodd-Frank Act), <ref target="PUBLIC_LAW:111-203" reftype="external">Public Law 111-203</ref>, <ref target="STATUTES_AT_LARGE:124-Stat.-1376" reftype="external">124 Stat. 1376</ref>. The purpose of this part is:</content>
+              <paragraph label="1013-1-b-1" marker="(1)">
+                <content>To ensure that <ref target="1013-2-g" reftype="term">lessees</ref> of <ref target="1013-2-l" reftype="term">personal property</ref> receive meaningful disclosures that enable them to compare <ref target="1013-2-e-1" reftype="term">lease</ref> terms with other <ref target="1013-2-e-1" reftype="term">leases</ref> and, where appropriate, with credit transactions;</content>
+              </paragraph>
+              <paragraph label="1013-1-b-2" marker="(2)">
+                <content>To limit the amount of balloon payments in <ref target="1013-2-e-1" reftype="term">consumer lease</ref> transactions; and</content>
+              </paragraph>
+              <paragraph label="1013-1-b-3" marker="(3)">
+                <content>To provide for the accurate disclosure of <ref target="1013-2-e-1" reftype="term">lease</ref> terms in advertising.</content>
+              </paragraph>
+            </paragraph>
+            <paragraph label="1013-1-c" marker="(c)">
+              <title type="keyterm">Enforcement and liability.</title>
+              <content>Section 108 of the <ref target="1013-2-a" reftype="term">Act</ref> contains the administrative enforcement provisions. Sections 112, 130, 131, and 185 of the <ref target="1013-2-a" reftype="term">Act</ref> contain the liability provisions for failing to comply with the requirements of the <ref target="1013-2-a" reftype="term">Act</ref> and this part.</content>
+            </paragraph>
+          </section>
+          <section label="1013-2" sectionNum="2">
+            <subject>§ 1013.2 Definitions.</subject>
+            <paragraph label="1013-2-p1" marker="">
+              <content>For the purposes of this part the following definitions apply:</content>
+            </paragraph>
+            <paragraph label="1013-2-a" marker="(a)">
+              <content><def term="act">Act</def> means the Truth in Lending Act (<ref target="USC:15-1601" reftype="external">15 U.S.C. 1601</ref> et seq.) and the Consumer Leasing Act is Chapter 5 of the Truth in Lending Act.</content>
+            </paragraph>
+            <paragraph label="1013-2-b" marker="(b)">
+              <content><def term="advertisement">Advertisement</def> means a commercial message in any medium that directly or indirectly promotes a <ref target="1013-2-e-1" reftype="term">consumer lease</ref> transaction.</content>
+            </paragraph>
+            <paragraph label="1013-2-c" marker="(c)">
+              <content><def term="bureau">Bureau</def> refers to the Bureau of Consumer Financial Protection.</content>
+            </paragraph>
+            <paragraph label="1013-2-d" marker="(d)">
+              <content><def term="closed-end lease">Closed-end lease</def> means a <ref target="1013-2-e-1" reftype="term">consumer lease</ref> other than an <ref target="1013-2-i" reftype="term">open-end lease</ref> as defined in this section.</content>
+            </paragraph>
+            <paragraph label="1013-2-e" marker="(e)">
+              <content/>
+              <paragraph label="1013-2-e-1" marker="(1)">
+                <content><def term="consumer lease">Consumer lease</def> means a contract in the form of a bailment or lease for the use of <ref target="1013-2-l" reftype="term">personal property</ref> by a natural <ref target="1013-2-k" reftype="term">person</ref> primarily for personal, family, or household purposes, for a period exceeding four months and for a total contractual obligation not exceeding the applicable threshold amount, whether or not the <ref target="1013-2-g" reftype="term">lessee</ref> has the option to purchase or otherwise become the owner of the property at the expiration of the lease. The threshold amount is adjusted annually to reflect increases in the Consumer Price Index for Urban Wage Earners and Clerical Workers, as applicable. See the official commentary to this paragraph <ref target="1013-2-e" reftype="internal">(e)</ref> for the threshold amount applicable to a specific consumer lease. Unless the context indicates otherwise, in this part “<def term="lease">lease</def>” means “consumer lease.”</content>
+              </paragraph>
+              <paragraph label="1013-2-e-2" marker="(2)">
+                <content>The term does not include a <ref target="1013-2-e-1" reftype="term">lease</ref> that meets the definition of a credit sale in Regulation Z (<ref target="CFR:12-226-2" reftype="external">12 CFR 226.2</ref>(a)). It also does not include a <ref target="1013-2-e-1" reftype="term">lease</ref> for agricultural, business, or commercial purposes or a <ref target="1013-2-e-1" reftype="term">lease</ref> made to an <ref target="1013-2-j" reftype="term">organization</ref>.</content>
+              </paragraph>
+              <paragraph label="1013-2-e-3" marker="(3)">
+                <content>This part does not apply to a <ref target="1013-2-e-1" reftype="term">lease</ref> transaction of <ref target="1013-2-l" reftype="term">personal property</ref> which is incident to the <ref target="1013-2-e-1" reftype="term">lease</ref> of real property and which provides that:</content>
+                <paragraph label="1013-2-e-3-i" marker="(i)">
+                  <content>The <ref target="1013-2-g" reftype="term">lessee</ref> has no liability for the value of the <ref target="1013-2-l" reftype="term">personal property</ref> at the end of the <ref target="1013-2-e-1" reftype="term">lease</ref> term except for abnormal wear and tear; and</content>
+                </paragraph>
+                <paragraph label="1013-2-e-3-ii" marker="(ii)">
+                  <content>The <ref target="1013-2-g" reftype="term">lessee</ref> has no option to purchase the leased property.</content>
+                </paragraph>
+              </paragraph>
+            </paragraph>
+            <paragraph label="1013-2-f" marker="(f)">
+              <content><def term="gross capitalized cost">Gross capitalized cost</def> means the amount agreed upon by the <ref target="1013-2-h" reftype="term">lessor</ref> and the <ref target="1013-2-g" reftype="term">lessee</ref> as the value of the leased property and any items that are capitalized or amortized during the <ref target="1013-2-e-1" reftype="term">lease</ref> term, including but not limited to taxes, insurance, service agreements, and any outstanding prior credit or <ref target="1013-2-e-1" reftype="term">lease</ref> balance. Capitalized cost reduction means the total amount of any rebate, cash payment, net trade-in allowance, and noncash credit that reduces the gross capitalized cost. The adjusted capitalized cost equals the gross capitalized cost less the capitalized cost reduction, and is the amount used by the <ref target="1013-2-h" reftype="term">lessor</ref> in calculating the base periodic payment.</content>
+            </paragraph>
+            <paragraph label="1013-2-g" marker="(g)">
+              <content><def term="lessee">Lessee</def> means a natural <ref target="1013-2-k" reftype="term">person</ref> who enters into or is offered a <ref target="1013-2-e-1" reftype="term">consumer lease</ref>.</content>
+            </paragraph>
+            <paragraph label="1013-2-h" marker="(h)">
+              <content><def term="lessor">Lessor</def> means a <ref target="1013-2-k" reftype="term">person</ref> who regularly <ref target="1013-2-e-1" reftype="term">leases</ref>, offers to <ref target="1013-2-e-1" reftype="term">lease</ref>, or arranges for the <ref target="1013-2-e-1" reftype="term">lease</ref> of <ref target="1013-2-l" reftype="term">personal property</ref> under a <ref target="1013-2-e-1" reftype="term">consumer lease</ref>. A <ref target="1013-2-k" reftype="term">person</ref> who has leased, offered, or arranged to <ref target="1013-2-e-1" reftype="term">lease</ref> <ref target="1013-2-l" reftype="term">personal property</ref> more than five times in the preceding calendar year or more than five times in the current calendar year is subject to <ref target="USC:0-0" reftype="external">the Act</ref> and this part.</content>
+            </paragraph>
+            <paragraph label="1013-2-i" marker="(i)">
+              <content><def term="open-end lease">Open-end lease</def> means a <ref target="1013-2-e-1" reftype="term">consumer lease</ref> in which the <ref target="1013-2-g" reftype="term">lessee</ref>'s liability at the end of the <ref target="1013-2-e-1" reftype="term">lease</ref> term is based on the difference between the <ref target="1013-2-n" reftype="term">residual value</ref> of the leased property and its <ref target="1013-2-m" reftype="term">realized value</ref>.</content>
+            </paragraph>
+            <paragraph label="1013-2-j" marker="(j)">
+              <content><def term="organization">Organization</def> means a corporation, trust, estate, partnership, cooperative, association, or government entity or instrumentality.</content>
+            </paragraph>
+            <paragraph label="1013-2-k" marker="(k)">
+              <content><def term="person">Person</def> means a natural person or an <ref target="1013-2-j" reftype="term">organization</ref>.</content>
+            </paragraph>
+            <paragraph label="1013-2-l" marker="(l)">
+              <content><def term="personal property">Personal property</def> means any property that is not real property under the law of the <ref target="1013-2-p" reftype="term">state</ref> where the property is located at the time it is offered or made available for <ref target="1013-2-e-1" reftype="term">lease</ref>.</content>
+            </paragraph>
+            <paragraph label="1013-2-m" marker="(m)">
+              <content><def term="realized value">Realized value</def> means:</content>
+              <paragraph label="1013-2-m-1" marker="(1)">
+                <content>The price received by the <ref target="1013-2-h" reftype="term">lessor</ref> for the leased property at disposition;</content>
+              </paragraph>
+              <paragraph label="1013-2-m-2" marker="(2)">
+                <content>The highest offer for disposition of the leased property; or</content>
+              </paragraph>
+              <paragraph label="1013-2-m-3" marker="(3)">
+                <content>The fair market value of the leased property at the end of the <ref target="1013-2-e-1" reftype="term">lease</ref> term.</content>
+              </paragraph>
+            </paragraph>
+            <paragraph label="1013-2-n" marker="(n)">
+              <content><def term="residual value">Residual value</def> means the value of the leased property at the end of the <ref target="1013-2-e-1" reftype="term">lease</ref> term, as estimated or assigned at consummation by the <ref target="1013-2-h" reftype="term">lessor</ref>, used in calculating the base periodic payment.</content>
+            </paragraph>
+            <paragraph label="1013-2-o" marker="(o)">
+              <content>Security interest and <def term="security">security</def> mean any interest in property that secures the payment or performance of an obligation.</content>
+            </paragraph>
+            <paragraph label="1013-2-p" marker="(p)">
+              <content><def term="state">State</def> means any state, the District of Columbia, the Commonwealth of Puerto Rico, and any territory or possession of the United States.</content>
+            </paragraph>
+          </section>
+          <section label="1013-3" sectionNum="3">
+            <subject>§ 1013.3 General disclosure requirements.</subject>
+            <paragraph label="1013-3-a" marker="(a)">
+              <title type="keyterm">General requirements.</title>
+              <content>A <ref target="1013-2-h" reftype="term">lessor</ref> shall make the disclosures required by § <ref target="1013-4" reftype="internal">1013.4</ref>, as applicable. The disclosures shall be made clearly and conspicuously in writing in a form the consumer may keep, in accordance with this section. The disclosures required by this part may be provided to the <ref target="1013-2-g" reftype="term">lessee</ref> in electronic form, subject to compliance with the consumer consent and other applicable provisions of the Electronic Signatures in Global and National Commerce Act (E-Sign Act) (<ref target="USC:15-7001" reftype="external">15 U.S.C. 7001</ref> et seq.). For an <ref target="1013-2-b" reftype="term">advertisement</ref> accessed by the consumer in electronic form, the disclosures required by § <ref target="1013-7" reftype="internal">1013.7</ref> may be provided to the consumer in electronic form in the <ref target="1013-2-b" reftype="term">advertisement</ref>, without regard to the consumer consent or other provisions of the E-Sign Act.</content>
+              <paragraph label="1013-3-a-1" marker="(1)">
+                <title type="keyterm">Form of disclosures.</title>
+                <content>The disclosures required by § <ref target="1013-4" reftype="internal">1013.4</ref> shall be given to the <ref target="1013-2-g" reftype="term">lessee</ref> together in a dated statement that identifies the <ref target="1013-2-h" reftype="term">lessor</ref> and the <ref target="1013-2-g" reftype="term">lessee</ref>; the disclosures may be made either in a separate statement that identifies the <ref target="1013-2-e-1" reftype="term">consumer lease</ref> transaction or in the contract or other document evidencing the <ref target="1013-2-e-1" reftype="term">lease</ref>. Alternatively, the disclosures required to be segregated from other information under paragraph <ref target="1013-3-a-2" reftype="internal">(a)(2)</ref> of this section may be provided in a separate dated statement that identifies the <ref target="1013-2-e-1" reftype="term">lease</ref>, and the other required disclosures may be provided in the <ref target="1013-2-e-1" reftype="term">lease</ref> contract or other document evidencing the <ref target="1013-2-e-1" reftype="term">lease</ref>. In a <ref target="1013-2-e-1" reftype="term">lease</ref> of multiple items, the property description required by § <ref target="1013-4-a" reftype="internal">1013.4(a)</ref> may be given in a separate statement that is included in the disclosure statement required by this paragraph.</content>
+              </paragraph>
+              <paragraph label="1013-3-a-2" marker="(2)">
+                <title type="keyterm">Segregation of certain disclosures.</title>
+                <content>The following disclosures shall be segregated from other information and shall contain only directly related information: §§ <ref target="1013-4-b" reftype="internal">1013.4(b)</ref> through <ref target="1013-4-f" reftype="internal">(f)</ref>, <ref target="1013-4-g-2" reftype="internal">(g)(2)</ref>, <ref target="1013-4-h-3" reftype="internal">(h)(3)</ref>, <ref target="1013-4-i-1" reftype="internal">(i)(1)</ref>, <ref target="1013-4-j" reftype="internal">(j)</ref>, and <ref target="1013-4-m-1" reftype="internal">(m)(1)</ref>. The headings, content, and format for the disclosures referred to in this paragraph <ref target="1013-3-a-2" reftype="internal">(a)(2)</ref> shall be provided in a manner substantially similar to the applicable model form in Appendix <ref target="1013-A" reftype="internal">A</ref> of this part.</content>
+              </paragraph>
+              <paragraph label="1013-3-a-3" marker="(3)">
+                <title type="keyterm">Timing of disclosures.</title>
+                <content>A <ref target="1013-2-h" reftype="term">lessor</ref> shall provide the disclosures to the <ref target="1013-2-g" reftype="term">lessee</ref> prior to the consummation of a <ref target="1013-2-e-1" reftype="term">consumer lease</ref>.</content>
+              </paragraph>
+              <paragraph label="1013-3-a-4" marker="(4)">
+                <title type="keyterm">Language of disclosures.</title>
+                <content>The disclosures required by § <ref target="1013-4" reftype="internal">1013.4</ref> may be made in a language other than English provided that they are made available in English upon the <ref target="1013-2-g" reftype="term">lessee</ref>'s request.</content>
+              </paragraph>
+            </paragraph>
+            <paragraph label="1013-3-b" marker="(b)">
+              <title type="keyterm">Additional information; nonsegregated disclosures.</title>
+              <content>Additional information may be provided with any disclosure not listed in paragraph <ref target="1013-3-a-2" reftype="internal">(a)(2)</ref> of this section, but it shall not be stated, used, or placed so as to mislead or confuse the <ref target="1013-2-g" reftype="term">lessee</ref> or contradict, obscure, or detract attention from any disclosure required by this part.</content>
+            </paragraph>
+            <paragraph label="1013-3-c" marker="(c)">
+              <title type="keyterm">Multiple lessors or lessees.</title>
+              <content>When a transaction involves more than one <ref target="1013-2-h" reftype="term">lessor</ref>, the disclosures required by this part may be made by one <ref target="1013-2-h" reftype="term">lessor</ref> on behalf of all the <ref target="1013-2-h" reftype="term">lessors</ref>. When a <ref target="1013-2-e-1" reftype="term">lease</ref> involves more than one <ref target="1013-2-g" reftype="term">lessee</ref>, the <ref target="1013-2-h" reftype="term">lessor</ref> may provide the disclosures to any <ref target="1013-2-g" reftype="term">lessee</ref> who is primarily liable on the <ref target="1013-2-e-1" reftype="term">lease</ref>.</content>
+            </paragraph>
+            <paragraph label="1013-3-d" marker="(d)">
+              <title type="keyterm">Use of estimates.</title>
+              <content>If an amount or other item needed to comply with a required disclosure is unknown or unavailable after reasonable efforts have been made to ascertain the information, the <ref target="1013-2-h" reftype="term">lessor</ref> may use a reasonable estimate that is based on the best information available to the <ref target="1013-2-h" reftype="term">lessor</ref>, is clearly identified as an estimate, and is not used to circumvent or evade any disclosures required by this part.</content>
+            </paragraph>
+            <paragraph label="1013-3-e" marker="(e)">
+              <title type="keyterm">Effect of subsequent occurrence.</title>
+              <content>If a required disclosure becomes inaccurate because of an event occurring after consummation, the inaccuracy is not a violation of this part.</content>
+            </paragraph>
+            <paragraph label="1013-3-f" marker="(f)">
+              <title type="keyterm">Minor variations.</title>
+              <content>A <ref target="1013-2-h" reftype="term">lessor</ref> may disregard the effects of the following in making disclosures:</content>
+              <paragraph label="1013-3-f-1" marker="(1)">
+                <content>That payments must be collected in whole cents;</content>
+              </paragraph>
+              <paragraph label="1013-3-f-2" marker="(2)">
+                <content>That dates of scheduled payments may be different because a scheduled date is not a business day;</content>
+              </paragraph>
+              <paragraph label="1013-3-f-3" marker="(3)">
+                <content>That months have different numbers of days; and</content>
+              </paragraph>
+              <paragraph label="1013-3-f-4" marker="(4)">
+                <content>That February 29 occurs in a leap year.</content>
+              </paragraph>
+            </paragraph>
+          </section>
+          <section label="1013-4" sectionNum="4">
+            <subject>§ 1013.4 Content of disclosures.</subject>
+            <paragraph label="1013-4-p1" marker="">
+              <content>For any <ref target="1013-2-e-1" reftype="term">consumer lease</ref> subject to this part, the <ref target="1013-2-h" reftype="term">lessor</ref> shall disclose the following information, as applicable:</content>
+            </paragraph>
+            <paragraph label="1013-4-a" marker="(a)">
+              <title type="keyterm">Description of property.</title>
+              <content>A brief description of the leased property sufficient to identify the property to the <ref target="1013-2-g" reftype="term">lessee</ref> and <ref target="1013-2-h" reftype="term">lessor</ref>.</content>
+            </paragraph>
+            <paragraph label="1013-4-b" marker="(b)">
+              <title type="keyterm">Amount due at lease signing or delivery.</title>
+              <content>The total amount to be paid prior to or at consummation or by delivery, if delivery occurs after consummation, using the term “amount due at <ref target="1013-2-e-1" reftype="term">lease</ref> signing or delivery.” The <ref target="1013-2-h" reftype="term">lessor</ref> shall itemize each component by type and amount, including any refundable <ref target="1013-2-o" reftype="term">security</ref> deposit, advance monthly or other periodic payment, and capitalized cost reduction; and in motor vehicle <ref target="1013-2-e-1" reftype="term">leases</ref>, shall itemize how the amount due will be paid, by type and amount, including any net trade-in allowance, rebates, noncash credits, and cash payments in a format substantially similar to the model forms in Appendix <ref target="1013-A" reftype="internal">A</ref> of this part.</content>
+            </paragraph>
+            <paragraph label="1013-4-c" marker="(c)">
+              <title type="keyterm"> Payment schedule and total amount of periodic payments.</title>
+              <content>The number, amount, and due dates or periods of payments scheduled under the <ref target="1013-2-e-1" reftype="term">lease</ref>, and the total amount of the periodic payments.</content>
+            </paragraph>
+            <paragraph label="1013-4-d" marker="(d)">
+              <title type="keyterm">Other charges.</title>
+              <content>The total amount of other charges payable to the <ref target="1013-2-h" reftype="term">lessor</ref>, itemized by type and amount, that are not included in the periodic payments. Such charges include the amount of any liability the <ref target="1013-2-e-1" reftype="term">lease</ref> imposes upon the <ref target="1013-2-g" reftype="term">lessee</ref> at the end of the <ref target="1013-2-e-1" reftype="term">lease</ref> term; the potential difference between the residual and <ref target="1013-2-m" reftype="term">realized values</ref> referred to in paragraph <ref target="1013-4-k" reftype="internal">(k)</ref> of this section is excluded.</content>
+            </paragraph>
+            <paragraph label="1013-4-e" marker="(e)">
+              <title type="keyterm">Total of payments.</title>
+              <content>The total of payments, with a description such as “the amount you will have paid by the end of the <ref target="1013-2-e-1" reftype="term">lease</ref>.” This amount is the sum of the amount due at <ref target="1013-2-e-1" reftype="term">lease</ref> signing (less any refundable amounts), the total amount of periodic payments (less any portion of the periodic payment paid at <ref target="1013-2-e-1" reftype="term">lease</ref> signing), and other charges under paragraphs <ref target="1013-4-b" reftype="internal">(b)</ref>, <ref target="1013-4-c" reftype="internal">(c)</ref>, and <ref target="1013-4-d" reftype="internal">(d)</ref> of this section. In an <ref target="1013-2-i" reftype="term">open-end lease</ref>, a description such as “you will owe an additional amount if the actual value of the vehicle is less than the <ref target="1013-2-n" reftype="term">residual value</ref>” shall accompany the disclosure.</content>
+            </paragraph>
+            <paragraph label="1013-4-f" marker="(f)">
+              <title type="keyterm">Payment calculation.</title>
+              <content>In a motor vehicle <ref target="1013-2-e-1" reftype="term">lease</ref>, a mathematical progression of how the scheduled periodic payment is derived, in a format substantially similar to the applicable model form in Appendix <ref target="1013-A" reftype="internal">A</ref> of this part, which shall contain the following:</content>
+              <paragraph label="1013-4-f-1" marker="(1)">
+                <title type="keyterm">Gross capitalized cost.</title>
+                <content>The <ref target="1013-2-f" reftype="term">gross capitalized cost</ref>, including a disclosure of the agreed upon value of the vehicle, a description such as “the agreed upon value of the vehicle [state the amount] and any items you pay for over the <ref target="1013-2-e-1" reftype="term">lease</ref> term (such as service contracts, insurance, and any outstanding prior credit or <ref target="1013-2-e-1" reftype="term">lease</ref> balance),” and a statement of the <ref target="1013-2-g" reftype="term">lessee</ref>'s option to receive a separate written itemization of the <ref target="1013-2-f" reftype="term">gross capitalized cost</ref>. If requested by the <ref target="1013-2-g" reftype="term">lessee</ref>, the itemization shall be provided before consummation.</content>
+              </paragraph>
+              <paragraph label="1013-4-f-2" marker="(2)">
+                <title type="keyterm">Capitalized cost reduction.</title>
+                <content>The capitalized cost reduction, with a description such as “the amount of any net trade-in allowance, rebate, noncash credit, or cash you pay that reduces the <ref target="1013-2-f" reftype="term">gross capitalized cost</ref>.”</content>
+              </paragraph>
+              <paragraph label="1013-4-f-3" marker="(3)">
+                <title type="keyterm">Adjusted capitalized cost.</title>
+                <content>The adjusted capitalized cost, with a description such as “the amount used in calculating your base [periodic] payment.”</content>
+              </paragraph>
+              <paragraph label="1013-4-f-4" marker="(4)">
+                <title type="keyterm">Residual value.</title>
+                <content>The <ref target="1013-2-n" reftype="term">residual value</ref>, with a description such as “the value of the vehicle at the end of the <ref target="1013-2-e-1" reftype="term">lease</ref> used in calculating your base [periodic] payment.”</content>
+              </paragraph>
+              <paragraph label="1013-4-f-5" marker="(5)">
+                <title type="keyterm">Depreciation and any amortized amounts.</title>
+                <content>The depreciation and any amortized amounts, which is the difference between the adjusted capitalized cost and the <ref target="1013-2-n" reftype="term">residual value</ref>, with a description such as “the amount charged for the vehicle's decline in value through normal use and for any other items paid over the <ref target="1013-2-e-1" reftype="term">lease</ref> term.”</content>
+              </paragraph>
+              <paragraph label="1013-4-f-6" marker="(6)">
+                <title type="keyterm">Rent charge.</title>
+                <content>The rent charge, with a description such as “the amount charged in addition to the depreciation and any amortized amounts.” This amount is the difference between the total of the base periodic payments over the <ref target="1013-2-e-1" reftype="term">lease</ref> term minus the depreciation and any amortized amounts.</content>
+              </paragraph>
+              <paragraph label="1013-4-f-7" marker="(7)">
+                <title type="keyterm">Total of base periodic payments.</title>
+                <content>The total of base periodic payments with a description such as “depreciation and any amortized amounts plus the rent charge.”</content>
+              </paragraph>
+              <paragraph label="1013-4-f-8" marker="(8)">
+                <title type="keyterm">Lease payments.</title>
+                <content>The <ref target="1013-2-e-1" reftype="term">lease</ref> payments with a description such as “the number of payments in your <ref target="1013-2-e-1" reftype="term">lease</ref>.”</content>
+              </paragraph>
+              <paragraph label="1013-4-f-9" marker="(9)">
+                <title type="keyterm">Base periodic payment.</title>
+                <content>The total of the base periodic payments divided by the number of payment periods in the <ref target="1013-2-e-1" reftype="term">lease</ref>.</content>
+              </paragraph>
+              <paragraph label="1013-4-f-10" marker="(10)">
+                <title type="keyterm">Itemization of other charges.</title>
+                <content>An itemization of any other charges that are part of the periodic payment.</content>
+              </paragraph>
+              <paragraph label="1013-4-f-11" marker="(11)">
+                <title type="keyterm">Total periodic payment.</title>
+                <content>The sum of the base periodic payment and any other charges that are part of the periodic payment.</content>
+              </paragraph>
+            </paragraph>
+            <paragraph label="1013-4-g" marker="(g)">
+              <title type="keyterm">Early termination</title>
+              <content>—</content>
+              <paragraph label="1013-4-g-1" marker="(1)">
+                <title type="keyterm">Conditions and disclosure of charges.</title>
+                <content>A statement of the conditions under which the <ref target="1013-2-g" reftype="term">lessee</ref> or <ref target="1013-2-h" reftype="term">lessor</ref> may terminate the <ref target="1013-2-e-1" reftype="term">lease</ref> prior to the end of the <ref target="1013-2-e-1" reftype="term">lease</ref> term; and the amount or a description of the method for determining the amount of any penalty or other charge for early termination, which must be reasonable.</content>
+              </paragraph>
+              <paragraph label="1013-4-g-2" marker="(2)">
+                <title type="keyterm">Early termination notice.</title>
+                <content>In a motor vehicle <ref target="1013-2-e-1" reftype="term">lease</ref>, a notice substantially similar to the following: “Early Termination. You may have to pay a substantial charge if you end this <ref target="1013-2-e-1" reftype="term">lease</ref> early. The charge may be up to several thousand dollars. The actual charge will depend on when the <ref target="1013-2-e-1" reftype="term">lease</ref> is terminated. The earlier you end the <ref target="1013-2-e-1" reftype="term">lease</ref>, the greater this charge is likely to be.”</content>
+              </paragraph>
+            </paragraph>
+            <paragraph label="1013-4-h" marker="(h)">
+              <title type="keyterm">Maintenance responsibilities.</title>
+              <content>The following provisions are required:</content>
+              <paragraph label="1013-4-h-1" marker="(1)">
+                <title type="keyterm">Statement of responsibilities.</title>
+                <content>A statement specifying whether the <ref target="1013-2-h" reftype="term">lessor</ref> or the <ref target="1013-2-g" reftype="term">lessee</ref> is responsible for maintaining or servicing the leased property, together with a brief description of the responsibility;</content>
+              </paragraph>
+              <paragraph label="1013-4-h-2" marker="(2)">
+                <title type="keyterm">Wear and use standard.</title>
+                <content>A statement of the <ref target="1013-2-h" reftype="term">lessor</ref>'s standards for wear and use (if any), which must be reasonable; and</content>
+              </paragraph>
+              <paragraph label="1013-4-h-3" marker="(3)">
+                <title type="keyterm">Notice of wear and use standard.</title>
+                <content>In a motor vehicle <ref target="1013-2-e-1" reftype="term">lease</ref>, a notice regarding wear and use substantially similar to the following: “Excessive Wear and Use. You may be charged for excessive wear based on our standards for normal use.” The notice shall also specify the amount or method for determining any charge for excess mileage.</content>
+              </paragraph>
+            </paragraph>
+            <paragraph label="1013-4-i" marker="(i)">
+              <title type="keyterm">Purchase option.</title>
+              <content>A statement of whether or not the <ref target="1013-2-g" reftype="term">lessee</ref> has the option to purchase the leased property, and:</content>
+              <paragraph label="1013-4-i-1" marker="(1)">
+                <title type="keyterm">End of lease term.</title>
+                <content>If at the end of the <ref target="1013-2-e-1" reftype="term">lease</ref> term, the purchase price; and</content>
+              </paragraph>
+              <paragraph label="1013-4-i-2" marker="(2)">
+                <title type="keyterm">During lease term.</title>
+                <content>If prior to the end of the <ref target="1013-2-e-1" reftype="term">lease</ref> term, the purchase price or the method for determining the price and when the <ref target="1013-2-g" reftype="term">lessee</ref> may exercise this option.</content>
+              </paragraph>
+            </paragraph>
+            <paragraph label="1013-4-j" marker="(j)">
+              <title type="keyterm">Statement referencing nonsegregated disclosures.</title>
+              <content>A statement that the <ref target="1013-2-g" reftype="term">lessee</ref> should refer to the <ref target="1013-2-e-1" reftype="term">lease</ref> documents for additional information on early termination, purchase options and maintenance responsibilities, warranties, late and default charges, insurance, and any <ref target="1013-2-o" reftype="term">security interests</ref>, if applicable.</content>
+            </paragraph>
+            <paragraph label="1013-4-k" marker="(k)">
+              <title type="keyterm">Liability between residual and realized values.</title>
+              <content>A statement of the <ref target="1013-2-g" reftype="term">lessee</ref>'s liability, if any, at early termination or at the end of the <ref target="1013-2-e-1" reftype="term">lease</ref> term for the difference between the <ref target="1013-2-n" reftype="term">residual value</ref> of the leased property and its <ref target="1013-2-m" reftype="term">realized value</ref>.</content>
+            </paragraph>
+            <paragraph label="1013-4-l" marker="(l)">
+              <title type="keyterm">Right of appraisal.</title>
+              <content>If the <ref target="1013-2-g" reftype="term">lessee</ref>'s liability at early termination or at the end of the <ref target="1013-2-e-1" reftype="term">lease</ref> term is based on the <ref target="1013-2-m" reftype="term">realized value</ref> of the leased property, a statement that the <ref target="1013-2-g" reftype="term">lessee</ref> may obtain, at the <ref target="1013-2-g" reftype="term">lessee</ref>'s expense, a professional appraisal by an independent third party (agreed to by the <ref target="1013-2-g" reftype="term">lessee</ref> and the <ref target="1013-2-h" reftype="term">lessor</ref>) of the value that could be realized at sale of the leased property. The appraisal shall be final and binding on the parties.</content>
+            </paragraph>
+            <paragraph label="1013-4-m" marker="(m)">
+              <title type="keyterm">Liability at end of lease term based on residual value.</title>
+              <content>If the <ref target="1013-2-g" reftype="term">lessee</ref> is liable at the end of the <ref target="1013-2-e-1" reftype="term">lease</ref> term for the difference between the <ref target="1013-2-n" reftype="term">residual value</ref> of the leased property and its <ref target="1013-2-m" reftype="term">realized value</ref>:</content>
+              <paragraph label="1013-4-m-1" marker="(1)">
+                <title type="keyterm">Rent and other charges.</title>
+                <content>The rent and other charges, paid by the <ref target="1013-2-g" reftype="term">lessee</ref> and required by the <ref target="1013-2-h" reftype="term">lessor</ref> as an incident to the <ref target="1013-2-e-1" reftype="term">lease</ref> transaction, with a description such as “the total amount of rent and other charges imposed in connection with your <ref target="1013-2-e-1" reftype="term">lease</ref> [state the amount].”</content>
+              </paragraph>
+              <paragraph label="1013-4-m-2" marker="(2)">
+                <title type="keyterm">Excess liability.</title>
+                <content>A statement about a rebuttable presumption that, at the end of the <ref target="1013-2-e-1" reftype="term">lease</ref> term, the <ref target="1013-2-n" reftype="term">residual value</ref> of the leased property is unreasonable and not in good faith to the extent that the <ref target="1013-2-n" reftype="term">residual value</ref> exceeds the <ref target="1013-2-m" reftype="term">realized value</ref> by more than three times the base monthly payment (or more than three times the average payment allocable to a monthly period, if the <ref target="1013-2-e-1" reftype="term">lease</ref> calls for periodic payments other than monthly); and that the <ref target="1013-2-h" reftype="term">lessor</ref> cannot collect the excess amount unless the <ref target="1013-2-h" reftype="term">lessor</ref> brings a successful court action and pays the <ref target="1013-2-g" reftype="term">lessee</ref>'s reasonable attorney's fees, or unless the excess of the <ref target="1013-2-n" reftype="term">residual value</ref> over the <ref target="1013-2-m" reftype="term">realized value</ref> is due to unreasonable or excessive wear or use of the leased property (in which case the rebuttable presumption does not apply).</content>
+              </paragraph>
+              <paragraph label="1013-4-m-3" marker="(3)">
+                <title type="keyterm">Mutually agreeable final adjustment.</title>
+                <content>A statement that the <ref target="1013-2-g" reftype="term">lessee</ref> and <ref target="1013-2-h" reftype="term">lessor</ref> are permitted, after termination of the <ref target="1013-2-e-1" reftype="term">lease</ref>, to make any mutually agreeable final adjustment regarding excess liability.</content>
+              </paragraph>
+            </paragraph>
+            <paragraph label="1013-4-n" marker="(n)">
+              <title type="keyterm">Fees and taxes.</title>
+              <content>The total dollar amount for all official and license fees, registration, title, or taxes required to be paid in connection with the <ref target="1013-2-e-1" reftype="term">lease</ref>.</content>
+            </paragraph>
+            <paragraph label="1013-4-o" marker="(o)">
+              <title type="keyterm">Insurance.</title>
+              <content>A brief identification of insurance in connection with the <ref target="1013-2-e-1" reftype="term">lease</ref> including:</content>
+              <paragraph label="1013-4-o-1" marker="(1)">
+                <title type="keyterm">Through the lessor.</title>
+                <content>If the insurance is provided by or paid through the <ref target="1013-2-h" reftype="term">lessor</ref>, the types and amounts of coverage and the cost to the <ref target="1013-2-g" reftype="term">lessee</ref>; or</content>
+              </paragraph>
+              <paragraph label="1013-4-o-2" marker="(2)">
+                <title type="keyterm">Through a third party.</title>
+                <content>If the <ref target="1013-2-g" reftype="term">lessee</ref> must obtain the insurance, the types and amounts of coverage required of the <ref target="1013-2-g" reftype="term">lessee</ref>.</content>
+              </paragraph>
+            </paragraph>
+            <paragraph label="1013-4-p" marker="(p)">
+              <title type="keyterm">Warranties or guarantees.</title>
+              <content>A statement identifying all express warranties and guarantees from the manufacturer or <ref target="1013-2-h" reftype="term">lessor</ref> with respect to the leased property that apply to the <ref target="1013-2-g" reftype="term">lessee</ref>.</content>
+            </paragraph>
+            <paragraph label="1013-4-q" marker="(q)">
+              <title type="keyterm">Penalties and other charges for delinquency.</title>
+              <content>The amount or the method of determining the amount of any penalty or other charge for delinquency, default, or late payments, which must be reasonable.</content>
+            </paragraph>
+            <paragraph label="1013-4-r" marker="(r)">
+              <title type="keyterm">Security interest.</title>
+              <content>A description of any <ref target="1013-2-o" reftype="term">security interest</ref>, other than a <ref target="1013-2-o" reftype="term">security</ref> deposit disclosed under paragraph <ref target="1013-4-b" reftype="internal">(b)</ref> of this section, held or to be retained by the <ref target="1013-2-h" reftype="term">lessor</ref>; and a clear identification of the property to which the <ref target="1013-2-o" reftype="term">security interest</ref> relates.</content>
+            </paragraph>
+            <paragraph label="1013-4-s" marker="(s)">
+              <title type="keyterm">Limitations on rate information.</title>
+              <content>If a <ref target="1013-2-h" reftype="term">lessor</ref> provides a percentage rate in an <ref target="1013-2-b" reftype="term">advertisement</ref> or in documents evidencing the <ref target="1013-2-e-1" reftype="term">lease</ref> transaction, a notice stating that “this percentage may not measure the overall cost of financing this <ref target="1013-2-e-1" reftype="term">lease</ref>” shall accompany the rate disclosure. The <ref target="1013-2-h" reftype="term">lessor</ref> shall not use the term “annual percentage rate,” “annual <ref target="1013-2-e-1" reftype="term">lease</ref> rate,” or any equivalent term.</content>
+            </paragraph>
+            <paragraph label="1013-4-t" marker="(t)">
+              <title type="keyterm">Non-motor vehicle open-end leases.</title>
+              <content>Non-motor vehicle <ref target="1013-2-i" reftype="term">open-end leases</ref> remain subject to section 182(10) of the <ref target="1013-2-a" reftype="term">Act</ref> regarding end of term liability.</content>
+            </paragraph>
+          </section>
+          <section label="1013-5" sectionNum="5">
+            <subject>§ 1013.5 Renegotiations, extensions, and assumptions.</subject>
+            <paragraph label="1013-5-a" marker="(a)">
+              <title type="keyterm">Renegotiation.</title>
+              <content>A renegotiation occurs when a <ref target="1013-2-e-1" reftype="term">consumer lease</ref> subject to this part is satisfied and replaced by a new <ref target="1013-2-e-1" reftype="term">lease</ref> undertaken by the same consumer. A renegotiation requires new disclosures, except as provided in paragraph <ref target="1013-5-d" reftype="internal">(d)</ref> of this section.</content>
+            </paragraph>
+            <paragraph label="1013-5-b" marker="(b)">
+              <title type="keyterm">Extension.</title>
+              <content>An extension is a continuation, agreed to by the <ref target="1013-2-h" reftype="term">lessor</ref> and the <ref target="1013-2-g" reftype="term">lessee</ref>, of an existing <ref target="1013-2-e-1" reftype="term">consumer lease</ref> beyond the originally scheduled end of the <ref target="1013-2-e-1" reftype="term">lease</ref> term, except when the continuation is the result of a renegotiation. An extension that exceeds six months requires new disclosures, except as provided in paragraph <ref target="1013-5-d" reftype="internal">(d)</ref> of this section.</content>
+            </paragraph>
+            <paragraph label="1013-5-c" marker="(c)">
+              <title type="keyterm">Assumption.</title>
+              <content>New disclosures are not required when a <ref target="1013-2-e-1" reftype="term">consumer lease</ref> is assumed by another <ref target="1013-2-k" reftype="term">person</ref>, whether or not the <ref target="1013-2-h" reftype="term">lessor</ref> charges an assumption fee.</content>
+            </paragraph>
+            <paragraph label="1013-5-d" marker="(d)">
+              <title type="keyterm">Exceptions.</title>
+              <content>New disclosures are not required for the following, even if they meet the definition of a renegotiation or an extension:</content>
+              <paragraph label="1013-5-d-1" marker="(1)">
+                <content>A reduction in the rent charge;</content>
+              </paragraph>
+              <paragraph label="1013-5-d-2" marker="(2)">
+                <content>The deferment of one or more payments, whether or not a fee is charged;</content>
+              </paragraph>
+              <paragraph label="1013-5-d-3" marker="(3)">
+                <content>The extension of a <ref target="1013-2-e-1" reftype="term">lease</ref> for not more than six months on a month-to-month basis or otherwise;</content>
+              </paragraph>
+              <paragraph label="1013-5-d-4" marker="(4)">
+                <content>A substitution of leased property with property that has a substantially equivalent or greater economic value, provided no other <ref target="1013-2-e-1" reftype="term">lease</ref> terms are changed;</content>
+              </paragraph>
+              <paragraph label="1013-5-d-5" marker="(5)">
+                <content>The addition, deletion, or substitution of leased property in a multiple-item <ref target="1013-2-e-1" reftype="term">lease</ref>, provided the average periodic payment does not change by more than 25 percent; or</content>
+              </paragraph>
+              <paragraph label="1013-5-d-6" marker="(6)">
+                <content>An agreement resulting from a court proceeding.</content>
+              </paragraph>
+            </paragraph>
+          </section>
+          <section label="1013-6" sectionNum="6">
+            <subject>§ 1013.6 [Reserved]</subject>
+            <reserved/>
+          </section>
+          <section label="1013-7" sectionNum="7">
+            <subject>§ 1013.7 Advertising.</subject>
+            <paragraph label="1013-7-a" marker="(a)">
+              <title type="keyterm">General rule.</title>
+              <content>An <ref target="1013-2-b" reftype="term">advertisement</ref> for a <ref target="1013-2-e-1" reftype="term">consumer lease</ref> may state that a specific <ref target="1013-2-e-1" reftype="term">lease</ref> of property at specific amounts or terms is available only if the <ref target="1013-2-h" reftype="term">lessor</ref> usually and customarily <ref target="1013-2-e-1" reftype="term">leases</ref> or will <ref target="1013-2-e-1" reftype="term">lease</ref> the property at those amounts or terms.</content>
+            </paragraph>
+            <paragraph label="1013-7-b" marker="(b)">
+              <title type="keyterm">Clear and conspicuous standard.</title>
+              <content>Disclosures required by this section shall be made clearly and conspicuously.</content>
+              <paragraph label="1013-7-b-1" marker="(1)">
+                <title type="keyterm">Amount due at lease signing or delivery.</title>
+                <content>Except for the statement of a periodic payment, any affirmative or negative reference to a charge that is a part of the disclosure required under paragraph <ref target="1013-7-d-2-ii" reftype="internal">(d)(2)(ii)</ref> of this section shall not be more prominent than that disclosure.</content>
+              </paragraph>
+              <paragraph label="1013-7-b-2" marker="(2)">
+                <title type="keyterm">Advertisement of a lease rate.</title>
+                <content>If a <ref target="1013-2-h" reftype="term">lessor</ref> provides a percentage rate in an <ref target="1013-2-b" reftype="term">advertisement</ref>, the rate shall not be more prominent than any of the disclosures in § <ref target="1013-4" reftype="internal">1013.4</ref>, with the exception of the notice in § <ref target="1013-4-s" reftype="internal">1013.4(s)</ref> required to accompany the rate; and the <ref target="1013-2-h" reftype="term">lessor</ref> shall not use the term “annual percentage rate,” “annual <ref target="1013-2-e-1" reftype="term">lease</ref> rate,” or equivalent term.</content>
+              </paragraph>
+            </paragraph>
+            <paragraph label="1013-7-c" marker="(c)">
+              <title type="keyterm">Catalogs or other multipage advertisements; electronic advertisements.</title>
+              <content>A catalog or other multipage <ref target="1013-2-b" reftype="term">advertisement</ref>, or an electronic <ref target="1013-2-b" reftype="term">advertisement</ref> (such as an <ref target="1013-2-b" reftype="term">advertisement</ref> appearing on an Internet Web site), that provides a table or schedule of the required disclosures shall be considered a single <ref target="1013-2-b" reftype="term">advertisement</ref> if, for <ref target="1013-2-e-1" reftype="term">lease</ref> terms that appear without all the required disclosures, the <ref target="1013-2-b" reftype="term">advertisement</ref> refers to the page or pages on which the table or schedule appears.</content>
+            </paragraph>
+            <paragraph label="1013-7-d" marker="(d)">
+              <title type="keyterm">Advertisement of terms that require additional disclosure.</title>
+              <content/>
+              <paragraph label="1013-7-d-1" marker="(1)">
+                <title type="keyterm">Triggering terms.</title>
+                <content>An <ref target="1013-2-b" reftype="term">advertisement</ref> that states any of the following items shall contain the disclosures required by paragraph <ref target="1013-7-d-2" reftype="internal">(d)(2)</ref> of this section, except as provided in paragraphs <ref target="1013-7-e" reftype="internal">(e)</ref> and <ref target="1013-7-f" reftype="internal">(f)</ref> of this section:</content>
+                <paragraph label="1013-7-d-1-i" marker="(i)">
+                  <content>The amount of any payment; or</content>
+                </paragraph>
+                <paragraph label="1013-7-d-1-ii" marker="(ii)">
+                  <content>A statement of any capitalized cost reduction or other payment (or that no payment is required) prior to or at consummation or by delivery, if delivery occurs after consummation.</content>
+                </paragraph>
+              </paragraph>
+              <paragraph label="1013-7-d-2" marker="(2)">
+                <title type="keyterm">Additional terms.</title>
+                <content>An <ref target="1013-2-b" reftype="term">advertisement</ref> stating any item listed in paragraph <ref target="1013-7-d-1" reftype="internal">(d)(1)</ref> of this section shall also state the following items:</content>
+                <paragraph label="1013-7-d-2-i" marker="(i)">
+                  <content>That the transaction advertised is a <ref target="1013-2-e-1" reftype="term">lease</ref>;</content>
+                </paragraph>
+                <paragraph label="1013-7-d-2-ii" marker="(ii)">
+                  <content>The total amount due prior to or at consummation or by delivery, if delivery occurs after consummation;</content>
+                </paragraph>
+                <paragraph label="1013-7-d-2-iii" marker="(iii)">
+                  <content>The number, amounts, and due dates or periods of scheduled payments under the <ref target="1013-2-e-1" reftype="term">lease</ref>;</content>
+                </paragraph>
+                <paragraph label="1013-7-d-2-iv" marker="(iv)">
+                  <content>A statement of whether or not a <ref target="1013-2-o" reftype="term">security</ref> deposit is required; and</content>
+                </paragraph>
+                <paragraph label="1013-7-d-2-v" marker="(v)">
+                  <content>A statement that an extra charge may be imposed at the end of the <ref target="1013-2-e-1" reftype="term">lease</ref> term where the <ref target="1013-2-g" reftype="term">lessee</ref>'s liability (if any) is based on the difference between the <ref target="1013-2-n" reftype="term">residual value</ref> of the leased property and its <ref target="1013-2-m" reftype="term">realized value</ref> at the end of the <ref target="1013-2-e-1" reftype="term">lease</ref> term.</content>
+                </paragraph>
+              </paragraph>
+            </paragraph>
+            <paragraph label="1013-7-e" marker="(e)">
+              <title type="keyterm">Alternative disclosures—merchandise tags.</title>
+              <content>A merchandise tag stating any item listed in paragraph <ref target="1013-7-d-1" reftype="internal">(d)(1)</ref> of this section may comply with paragraph <ref target="1013-7-d-2" reftype="internal">(d)(2)</ref> of this section by referring to a sign or display prominently posted in the <ref target="1013-2-h" reftype="term">lessor</ref>'s place of business that contains a table or schedule of the required disclosures.</content>
+            </paragraph>
+            <paragraph label="1013-7-f" marker="(f)">
+              <title type="keyterm">Alternative disclosures—television or radio advertisements</title>
+              <content>—</content>
+              <paragraph label="1013-7-f-1" marker="(1)">
+                <title type="keyterm">Toll-free number or print advertisement.</title>
+                <content>An <ref target="1013-2-b" reftype="term">advertisement</ref> made through television or radio stating any item listed in paragraph <ref target="1013-7-d-1" reftype="internal">(d)(1)</ref> of this section complies with paragraph <ref target="1013-7-d-2" reftype="internal">(d)(2)</ref> of this section if the <ref target="1013-2-b" reftype="term">advertisement</ref> states the items listed in paragraphs <ref target="1013-7-d-2-i" reftype="internal">(d)(2)(i)</ref> through <ref target="1013-7-d-2-iii" reftype="internal">(iii)</ref> of this section, and:</content>
+                <paragraph label="1013-7-f-1-i" marker="(i)">
+                  <content>Lists a toll-free telephone number along with a reference that such number may be used by consumers to obtain the information required by paragraph <ref target="1013-7-d-2" reftype="internal">(d)(2)</ref> of this section; or</content>
+                </paragraph>
+                <paragraph label="1013-7-f-1-ii" marker="(ii)">
+                  <content>Directs the consumer to a written <ref target="1013-2-b" reftype="term">advertisement</ref> in a publication of general circulation in the community served by the media station, including the name and the date of the publication, with a statement that information required by paragraph <ref target="1013-7-d-2" reftype="internal">(d)(2)</ref> of this section is included in the <ref target="1013-2-b" reftype="term">advertisement</ref>. The written <ref target="1013-2-b" reftype="term">advertisement</ref> shall be published beginning at least three days before and ending at least ten days after the broadcast.</content>
+                </paragraph>
+              </paragraph>
+              <paragraph label="1013-7-f-2" marker="(2)">
+                <title type="keyterm">Establishment of toll-free number.</title>
+                <content/>
+                <paragraph label="1013-7-f-2-i" marker="(i)">
+                  <content>The toll-free telephone number shall be available for no fewer than ten days, beginning on the date of the broadcast.</content>
+                </paragraph>
+                <paragraph label="1013-7-f-2-ii" marker="(ii)">
+                  <content>The <ref target="1013-2-h" reftype="term">lessor</ref> shall provide the information required by paragraph <ref target="1013-7-d-2" reftype="internal">(d)(2)</ref> of this section orally, or in writing upon request.</content>
+                </paragraph>
+              </paragraph>
+            </paragraph>
+          </section>
+          <section label="1013-8" sectionNum="8">
+            <subject>§ 1013.8 Record retention.</subject>
+            <paragraph label="1013-8-p1" marker="">
+              <content>A lessor shall retain evidence of compliance with the requirements imposed by this part, other than the advertising requirements under § 1013.7, for a period of not less than two years after the date the disclosures are required to be made or an action is required to be taken.</content>
+            </paragraph>
+          </section>
+          <section label="1013-9" sectionNum="9">
+            <subject>§ 1013.9 Relation to state laws.</subject>
+            <paragraph label="1013-9-a" marker="(a)">
+              <title type="keyterm">Inconsistent state law.</title>
+              <content>A <ref target="1013-2-p" reftype="term">state</ref> law that is inconsistent with the requirements of the <ref target="1013-2-a" reftype="term">Act</ref> and this part is preempted to the extent of the inconsistency. If a <ref target="1013-2-h" reftype="term">lessor</ref> cannot comply with a <ref target="1013-2-p" reftype="term">state</ref> law without violating a provision of this part, the <ref target="1013-2-p" reftype="term">state</ref> law is inconsistent within the meaning of section 186(a) of the <ref target="1013-2-a" reftype="term">Act</ref> and is preempted, unless the <ref target="1013-2-p" reftype="term">state</ref> law gives greater protection and benefit to the consumer. A <ref target="1013-2-p" reftype="term">state</ref>, through an official having primary enforcement or interpretative responsibilities for the <ref target="1013-2-p" reftype="term">state</ref> consumer leasing law, may apply to the <ref target="1013-2-c" reftype="term">Bureau</ref> for a preemption determination.</content>
+            </paragraph>
+            <paragraph label="1013-9-b" marker="(b)">
+              <title type="keyterm">Exemptions</title>
+              <content>—</content>
+              <paragraph label="1013-9-b-1" marker="(1)">
+                <title type="keyterm">Application.</title>
+                <content>A <ref target="1013-2-p" reftype="term">state</ref> may apply to the <ref target="1013-2-c" reftype="term">Bureau</ref> for an exemption from the requirements of the <ref target="1013-2-a" reftype="term">Act</ref> and this part for any class of <ref target="1013-2-e-1" reftype="term">lease</ref> transactions within the <ref target="1013-2-p" reftype="term">state</ref>. The <ref target="1013-2-c" reftype="term">Bureau</ref> will grant such an exemption if the <ref target="1013-2-c" reftype="term">Bureau</ref> determines that:</content>
+                <paragraph label="1013-9-b-1-i" marker="(i)">
+                  <content>The class of leasing transactions is subject to <ref target="1013-2-p" reftype="term">state</ref> law requirements substantially similar to the <ref target="1013-2-a" reftype="term">Act</ref> and this part or that <ref target="1013-2-g" reftype="term">lessees</ref> are afforded greater protection under <ref target="1013-2-p" reftype="term">state</ref> law; and</content>
+                </paragraph>
+                <paragraph label="1013-9-b-1-ii" marker="(ii)">
+                  <content>There is adequate provision for <ref target="1013-2-p" reftype="term">state</ref> enforcement.</content>
+                </paragraph>
+              </paragraph>
+              <paragraph label="1013-9-b-2" marker="(2)">
+                <title type="keyterm">Enforcement and liability.</title>
+                <content>After an exemption has been granted, the requirements of the applicable <ref target="1013-2-p" reftype="term">state</ref> law (except for additional requirements not imposed by Federal law) will constitute the requirements of the <ref target="1013-2-a" reftype="term">Act</ref> and this part. No exemption will extend to the civil liability provisions of sections 130, 131, and 185 of the <ref target="1013-2-a" reftype="term">Act</ref>.</content>
+              </paragraph>
+            </paragraph>
+          </section>
+        </content>
+      </subpart>
+      <appendix appendixLetter="A" label="1013-A">
+        <appendixTitle>Appendix A to Part 1013—Model Forms</appendixTitle>
+        <tableOfContents>
+          <tocAppEntry target="1013-A-1">
+            <appendixLetter>1</appendixLetter>
+            <appendixSubject>A-1—Model Open-End or Finance Vehicle Lease Disclosures</appendixSubject>
+          </tocAppEntry>
+          <tocAppEntry target="1013-A-2">
+            <appendixLetter>2</appendixLetter>
+            <appendixSubject>A-2—Model Closed-End or Net Vehicle Lease Disclosures</appendixSubject>
+          </tocAppEntry>
+          <tocAppEntry target="1013-A-3">
+            <appendixLetter>3</appendixLetter>
+            <appendixSubject>A-3—Model Furniture Lease Disclosures</appendixSubject>
+          </tocAppEntry>
+        </tableOfContents>
+        <appendixSection appendixSecNum="1" label="1013-A-1">
+          <subject>A-1—Model Open-End or Finance Vehicle Lease Disclosures</subject>
+          <paragraph label="1013-A-1-p1" marker="">
+            <content>
+              <graphic>
+                <altText/>
+                <text>![](ER19DE11.010)</text>
+                <url>https://s3.amazonaws.com/images.federalregister.gov/ER19DE11.010/original.gif</url>
+              </graphic>
+            </content>
+          </paragraph>
+          <paragraph label="1013-A-1-p2" marker="">
+            <content>
+              <graphic>
+                <altText/>
+                <text>![](ER19DE11.011)</text>
+                <url>https://s3.amazonaws.com/images.federalregister.gov/ER19DE11.011/original.gif</url>
+              </graphic>
+            </content>
+          </paragraph>
+        </appendixSection>
+        <appendixSection appendixSecNum="2" label="1013-A-2">
+          <subject>A-2—Model Closed-End or Net Vehicle Lease Disclosures</subject>
+          <paragraph label="1013-A-2-p1" marker="">
+            <content>
+              <graphic>
+                <altText/>
+                <text>![](ER19DE11.012)</text>
+                <url>https://s3.amazonaws.com/images.federalregister.gov/ER19DE11.012/original.gif</url>
+              </graphic>
+            </content>
+          </paragraph>
+          <paragraph label="1013-A-2-p2" marker="">
+            <content>
+              <graphic>
+                <altText/>
+                <text>![](ER19DE11.013)</text>
+                <url>https://s3.amazonaws.com/images.federalregister.gov/ER19DE11.013/original.gif</url>
+              </graphic>
+            </content>
+          </paragraph>
+        </appendixSection>
+        <appendixSection appendixSecNum="3" label="1013-A-3">
+          <subject>A-3—Model Furniture Lease Disclosures</subject>
+          <paragraph label="1013-A-3-p1" marker="">
+            <content>
+              <graphic>
+                <altText/>
+                <text>![](ER19DE11.014)</text>
+                <url>https://s3.amazonaws.com/images.federalregister.gov/ER19DE11.014/original.gif</url>
+              </graphic>
+            </content>
+          </paragraph>
+          <paragraph label="1013-A-3-p2" marker="">
+            <content>
+              <graphic>
+                <altText/>
+                <text>![](ER19DE11.015)</text>
+                <url>https://s3.amazonaws.com/images.federalregister.gov/ER19DE11.015/original.gif</url>
+              </graphic>
+            </content>
+          </paragraph>
+        </appendixSection>
+      </appendix>
+      <appendix appendixLetter="B" label="1013-B">
+        <appendixTitle>Appendix B to Part 1013 [Reserved]</appendixTitle>
+        <reserved/>
+      </appendix>
+      <appendix appendixLetter="C" label="1013-C">
+        <appendixTitle>Appendix C to Part 1013—Issuance of Official Interpretations</appendixTitle>
+        <appendixSection appendixSecNum="1" label="1013-C-p1">
+          <subject/>
+          <paragraph label="1013-C-p1-p1" marker="">
+            <content>Interpretations of this part issued by officials of the Bureau provide the formal protection afforded under section 130(f) of the Act. Except in unusual circumstances, interpretations will not be issued separately but will be incorporated in an official commentary to Regulation M (Supplement I of this part), which will be amended periodically. No official interpretations will be issued approving a lessor's forms, statements, or calculation tools or methods.</content>
+          </paragraph>
+        </appendixSection>
+      </appendix>
+      <interpretations label="1013-Interp">
+	<tableOfContents>
+	  <tocInterpEntry target="1013-Interp-h1">
+	    <interpTitle>Introduction</interpTitle>
+	  </tocInterpEntry>
+	</tableOfContents>
+        <title>Supplement I to Part 1013—Official Interpretations</title>
+        <interpSection label="1013-Interp-h1">
+          <title>Introduction</title>
+          <interpParagraph label="1013-Interp-h1-1" marker="1.">
+            <title type="keyterm">Official status.</title>
+            <content>The commentary in Supplement I is the vehicle by which the Bureau of Consumer Financial Protection issues official interpretations of Regulation M (<ref target="CFR:12-1013" reftype="external">12 CFR part 1013</ref>). Good faith compliance with this commentary affords protection from liability under section 130(f) of the Truth in Lending Act (<ref target="USC:15-1640" reftype="external">15 U.S.C. 1640</ref>(f)). Section 130(f) protects <ref target="1013-2-h" reftype="term">lessors</ref> from civil liability for any act done or omitted in good faith in conformity with any interpretation issued by the <ref target="1013-2-c" reftype="term">Bureau</ref>.</content>
+          </interpParagraph>
+          <interpParagraph label="1013-Interp-h1-2" marker="2.">
+            <title type="keyterm">Procedures for requesting interpretations.</title>
+            <content>Under Appendix <ref target="1013-C" reftype="internal">C</ref> of Regulation M, anyone may request an official interpretation. Interpretations that are adopted will be incorporated in this commentary following publication in the Federal Register. No official interpretations are expected to be issued other than by means of this commentary.</content>
+          </interpParagraph>
+          <interpParagraph label="1013-Interp-h1-3" marker="3.">
+            <title type="keyterm">Comment designations.</title>
+            <content>Each comment in the commentary is identified by a number and the regulatory section or paragraph that it interprets. The comments are designated with as much specificity as possible according to the particular regulatory provision addressed. For example, some of the comments to § <ref target="1013-4-f" reftype="internal">1013.4(f)</ref> are further divided by subparagraph, such as comment <ref target="1013-4-f-1-Interp-1" reftype="internal">4(f)(1)-1</ref> and comment 4(f)(2)-1. In other cases, comments have more general application and are designated, for example, as comment <ref target="1013-4-a-Interp-1" reftype="internal">4(a)-1</ref>. This introduction may be cited as comments I-1 through I-4. An appendix may be cited as comment app. <ref target="1013-A-1" reftype="internal">A-1</ref>.</content>
+          </interpParagraph>
+          <interpParagraph label="1013-Interp-h1-4" marker="4.">
+            <title type="keyterm">Illustrations.</title>
+            <content>Lists that appear in the commentary may be exhaustive or illustrative; the appropriate construction should be clear from the context. Illustrative lists are introduced by phrases such as “including,” “such as,” “to illustrate,” and “for example.”</content>
+          </interpParagraph>
+        </interpSection>
+        <interpSection label="1013-1-Interp" sectionNum="1" target="1013-1">
+          <title>Section 1013.1—Authority, Scope, Purpose, and Enforcement</title>
+          <interpParagraph label="1013-1-Interp-1" marker="1.">
+            <title type="keyterm">Foreign applicability.</title>
+            <content>Regulation M applies to all <ref target="1013-2-k" reftype="term">persons</ref> (including branches of foreign banks or leasing companies located in the United States) that offer <ref target="1013-2-e-1" reftype="term">consumer leases</ref> to residents of any <ref target="1013-2-p" reftype="term">state</ref> (including foreign nationals) as defined in § <ref target="1013-2-p" reftype="internal">1013.2(p)</ref>, except <ref target="1013-2-k" reftype="term">persons</ref> excluded from coverage of this part by section 1029 of the Consumer Financial Protection Act of 2010, Title X of the Dodd-Frank Wall Street Reform and Consumer Protection Act, Pub. L. 111-203, <ref target="STATUTES_AT_LARGE:124-Stat.-1376" reftype="external">124 Stat. 1376</ref>. The regulation does not apply to a foreign branch of a U.S. bank or to a leasing company leasing to a U.S. citizen residing or visiting abroad or to a foreign national abroad.</content>
+          </interpParagraph>
+        </interpSection>
+        <interpSection label="1013-2-Interp" sectionNum="2">
+          <title>Section 1013.2—Definitions</title>
+          <interpParagraph label="1013-2-b-Interp" target="1013-2-b">
+            <title>2(b) Advertisement</title>
+            <content/>
+            <interpParagraph label="1013-2-b-Interp-1" marker="1.">
+              <title type="keyterm">Coverage.</title>
+              <content>The term <ref target="1013-2-b" reftype="term">advertisement</ref> includes messages inviting, offering, or otherwise generally announcing to prospective customers the availability of <ref target="1013-2-e-1" reftype="term">consumer leases</ref>, whether in visual, oral, print or electronic media. Examples include:</content>
+              <interpParagraph label="1013-2-b-Interp-1-i" marker="i.">
+                <content>Messages in newspapers, magazines, leaflets, catalogs, and fliers.</content>
+              </interpParagraph>
+              <interpParagraph label="1013-2-b-Interp-1-ii" marker="ii.">
+                <content>Messages on radio, television, and public address systems.</content>
+              </interpParagraph>
+              <interpParagraph label="1013-2-b-Interp-1-iii" marker="iii.">
+                <content>Direct mail literature.</content>
+              </interpParagraph>
+              <interpParagraph label="1013-2-b-Interp-1-iv" marker="iv.">
+                <content>Printed material on any interior or exterior sign or display, in any window display, in any point-of-transaction literature or price tag that is delivered or made available to a <ref target="1013-2-g" reftype="term">lessee</ref> or prospective <ref target="1013-2-g" reftype="term">lessee</ref> in any manner whatsoever.</content>
+              </interpParagraph>
+              <interpParagraph label="1013-2-b-Interp-1-v" marker="v.">
+                <content>Telephone solicitations.</content>
+              </interpParagraph>
+              <interpParagraph label="1013-2-b-Interp-1-vi" marker="vi.">
+                <content>Online messages, such as those on the Internet.</content>
+              </interpParagraph>
+            </interpParagraph>
+            <interpParagraph label="1013-2-b-Interp-2" marker="2.">
+              <title type="keyterm">Exclusions.</title>
+              <content>The term does not apply to the following:</content>
+              <interpParagraph label="1013-2-b-Interp-2-i" marker="i.">
+                <content>Direct personal contacts, including follow-up letters, cost estimates for individual <ref target="1013-2-g" reftype="term">lessees</ref>, or oral or written communications relating to the negotiation of a specific transaction.</content>
+              </interpParagraph>
+              <interpParagraph label="1013-2-b-Interp-2-ii" marker="ii.">
+                <content>Informational material distributed only to businesses.</content>
+              </interpParagraph>
+              <interpParagraph label="1013-2-b-Interp-2-iii" marker="iii.">
+                <content>Notices required by Federal or <ref target="1013-2-p" reftype="term">state</ref> law, if the law mandates that specific information be displayed and only the mandated information is included in the notice.</content>
+              </interpParagraph>
+              <interpParagraph label="1013-2-b-Interp-2-iv" marker="iv.">
+                <content>News articles controlled by the news medium.</content>
+              </interpParagraph>
+              <interpParagraph label="1013-2-b-Interp-2-v" marker="v.">
+                <content>Market research or educational materials that do not solicit business.</content>
+              </interpParagraph>
+            </interpParagraph>
+            <interpParagraph label="1013-2-b-Interp-3" marker="3.">
+              <title type="keyterm">Persons covered.</title>
+              <content>See the commentary to § <ref target="1013-7-a-Interp" reftype="internal">1013.7(a)</ref>.</content>
+            </interpParagraph>
+          </interpParagraph>
+          <interpParagraph label="1013-2-d-Interp" target="1013-2-d">
+            <title>2(d) Closed-End Lease</title>
+            <content/>
+            <interpParagraph label="1013-2-d-Interp-1" marker="1.">
+              <title type="keyterm">General.</title>
+              <content>In <ref target="1013-2-d" reftype="term">closed-end leases</ref>, sometimes referred to as “walk-away” <ref target="1013-2-e-1" reftype="term">leases</ref>, the <ref target="1013-2-g" reftype="term">lessee</ref> is not responsible for the <ref target="1013-2-n" reftype="term">residual value</ref> of the leased property at the end of the <ref target="1013-2-e-1" reftype="term">lease</ref> term.</content>
+            </interpParagraph>
+          </interpParagraph>
+          <interpParagraph label="1013-2-e-Interp" target="1013-2-e">
+            <title>2(e) Consumer Lease</title>
+            <content/>
+            <interpParagraph label="1013-2-e-Interp-1" marker="1.">
+              <title type="keyterm">Primary purposes.</title>
+              <content>A <ref target="1013-2-h" reftype="term">lessor</ref> must determine in each case if the leased property will be used primarily for personal, family, or household purposes. If a question exists as to the primary purpose for a <ref target="1013-2-e-1" reftype="term">lease</ref>, the fact that a <ref target="1013-2-h" reftype="term">lessor</ref> gives disclosures is not controlling on the question of whether the transaction is covered. The primary purpose of a <ref target="1013-2-e-1" reftype="term">lease</ref> is determined before or at consummation and a <ref target="1013-2-h" reftype="term">lessor</ref> need not provide Regulation M disclosures where there is a subsequent change in the primary use.</content>
+            </interpParagraph>
+            <interpParagraph label="1013-2-e-Interp-2" marker="2.">
+              <title type="keyterm">Period of time.</title>
+              <content>To be a <ref target="1013-2-e-1" reftype="term">consumer lease</ref>, the initial term of the <ref target="1013-2-e-1" reftype="term">lease</ref> must be more than four months. Thus, a <ref target="1013-2-e-1" reftype="term">lease</ref> of <ref target="1013-2-l" reftype="term">personal property</ref> for four months, three months or on a month-to-month or week-to-week basis (even though the <ref target="1013-2-e-1" reftype="term">lease</ref> actually extends beyond four months) is not a <ref target="1013-2-e-1" reftype="term">consumer lease</ref> and is not subject to the disclosure requirements of the regulation. However, a <ref target="1013-2-e-1" reftype="term">lease</ref> that imposes a penalty for not continuing the <ref target="1013-2-e-1" reftype="term">lease</ref> beyond four months is considered to have a term of more than four months. To illustrate:</content>
+              <interpParagraph label="1013-2-e-Interp-2-i" marker="i.">
+                <content>A three-month <ref target="1013-2-e-1" reftype="term">lease</ref> extended on a month-to-month basis and terminated after one year is not subject to the regulation.</content>
+              </interpParagraph>
+              <interpParagraph label="1013-2-e-Interp-2-ii" marker="ii.">
+                <content>A month-to-month <ref target="1013-2-e-1" reftype="term">lease</ref> with a penalty, such as the forfeiture of a <ref target="1013-2-o" reftype="term">security</ref> deposit for terminating before one year, is subject to the regulation.</content>
+              </interpParagraph>
+            </interpParagraph>
+            <interpParagraph label="1013-2-e-Interp-3" marker="3.">
+              <title type="keyterm">Total contractual obligation.</title>
+              <content>The total contractual obligation is not necessarily the same as the total of payments disclosed under § <ref target="1013-4-e" reftype="internal">1013.4(e)</ref>. The total contractual obligation includes nonrefundable amounts a <ref target="1013-2-g" reftype="term">lessee</ref> is contractually obligated to pay to the <ref target="1013-2-h" reftype="term">lessor</ref>, but excludes items such as:</content>
+              <interpParagraph label="1013-2-e-Interp-3-i" marker="i.">
+                <content><ref target="1013-2-n" reftype="term">Residual value</ref> amounts or purchase-option prices;</content>
+              </interpParagraph>
+              <interpParagraph label="1013-2-e-Interp-3-ii" marker="ii.">
+                <content>Amounts collected by the <ref target="1013-2-h" reftype="term">lessor</ref> but paid to a third party, such as taxes, licenses, and registration fees.</content>
+              </interpParagraph>
+            </interpParagraph>
+            <interpParagraph label="1013-2-e-Interp-4" marker="4.">
+              <title type="keyterm">Credit sale.</title>
+              <content>The regulation does not cover a <ref target="1013-2-e-1" reftype="term">lease</ref> that meets the definition of a credit sale in Regulation Z, <ref target="CFR:12-226-2" reftype="external">12 CFR 226.2</ref>(a)(16), which is defined, in part, as a bailment or <ref target="1013-2-e-1" reftype="term">lease</ref> (unless terminable without penalty at any time by the consumer) under which the consumer:</content>
+              <interpParagraph label="1013-2-e-Interp-4-i" marker="i.">
+                <content>Agrees to pay as compensation for use a sum substantially equivalent to, or in excess of, the total value of the property and services involved; and</content>
+              </interpParagraph>
+              <interpParagraph label="1013-2-e-Interp-4-ii" marker="ii.">
+                <content>Will become (or has the option to become), for no additional consideration or for nominal consideration, the owner of the property upon compliance with the agreement.</content>
+              </interpParagraph>
+            </interpParagraph>
+            <interpParagraph label="1013-2-e-Interp-5" marker="5.">
+              <title type="keyterm">Agricultural purpose.</title>
+              <content>Agricultural purpose means a purpose related to the production, harvest, exhibition, marketing, transportation, processing, or manufacture of agricultural products by a natural <ref target="1013-2-k" reftype="term">person</ref> who cultivates, plants, propagates, or nurtures those agricultural products, including but not limited to the acquisition of <ref target="1013-2-l" reftype="term">personal property</ref> and services used primarily in farming. Agricultural products include horticultural, viticultural, and dairy products, livestock, wildlife, poultry, bees, forest products, fish and shellfish, and any products thereof, including processed and manufactured products, and any and all products raised or produced on farms and any processed or manufactured products thereof.</content>
+            </interpParagraph>
+            <interpParagraph label="1013-2-e-Interp-6" marker="6.">
+              <title type="keyterm">Organization or other entity.</title>
+              <content>A <ref target="1013-2-e-1" reftype="term">consumer lease</ref> does not include a <ref target="1013-2-e-1" reftype="term">lease</ref> made to an <ref target="1013-2-j" reftype="term">organization</ref> such as a corporation or a government agency or instrumentality. Such a <ref target="1013-2-e-1" reftype="term">lease</ref> is not covered by the regulation even if the leased property is used (by an employee, for example) primarily for personal, family or household purposes, or is guaranteed by or subsequently assigned to a natural <ref target="1013-2-k" reftype="term">person</ref>.</content>
+            </interpParagraph>
+            <interpParagraph label="1013-2-e-Interp-7" marker="7.">
+              <title type="keyterm">Leases of personal property incidental to a service.</title>
+              <content>The following <ref target="1013-2-e-1" reftype="term">leases</ref> of <ref target="1013-2-l" reftype="term">personal property</ref> are deemed incidental to a service and thus are not subject to the regulation:</content>
+              <interpParagraph label="1013-2-e-Interp-7-i" marker="i.">
+                <content>Home entertainment systems requiring the consumer to <ref target="1013-2-e-1" reftype="term">lease</ref> equipment that enables a television to receive the transmitted programming.</content>
+              </interpParagraph>
+              <interpParagraph label="1013-2-e-Interp-7-ii" marker="ii.">
+                <content>Security alarm systems requiring the installation of leased equipment intended to monitor unlawful entries into a home and in some cases to provide fire protection.</content>
+              </interpParagraph>
+              <interpParagraph label="1013-2-e-Interp-7-iii" marker="iii.">
+                <content>Propane gas service where the consumer must <ref target="1013-2-e-1" reftype="term">lease</ref> a propane tank to receive the service.</content>
+              </interpParagraph>
+            </interpParagraph>
+            <interpParagraph label="1013-2-e-Interp-8" marker="8.">
+              <title type="keyterm">Safe deposit boxes.</title>
+              <content>The <ref target="1013-2-e-1" reftype="term">lease</ref> of a safe deposit box is not a <ref target="1013-2-e-1" reftype="term">consumer lease</ref> under § <ref target="1013-2-e" reftype="internal">1013.2(e)</ref>.</content>
+            </interpParagraph>
+            <interpParagraph label="1013-2-e-Interp-9" marker="9.">
+        <title type="keyterm">Threshold amount.</title>
+        <content>A <ref target="1013-2-e-1" reftype="term">consumer lease</ref> is exempt from the requirements of this part if the total contractual obligation exceeds the threshold amount in effect at the time of consummation. The threshold amount in effect during a particular time period is the amount stated in comment <ref target="1013-2-e-11" reftype="internal">2(e)-11</ref> for that period. The threshold amount is adjusted effective January 1 of each year by any annual percentage increase in the Consumer Price Index for Urban Wage Earners and Clerical Workers (CPI-W) that was in effect on the preceding June 1. Comment <ref target="1013-2-e-11" reftype="internal">2(e)-11</ref> will be amended to provide the threshold amount for the upcoming year after the annual percentage change in the CPI-W that was in effect on June 1 becomes available. Any increase in the threshold amount will be rounded to the nearest $100 increment. For example, if the annual percentage increase in the CPI-W would result in a $950 increase in the threshold amount, the threshold amount will be increased by $1,000. However, if the annual percentage increase in the CPI-W would result in a $949 increase in the threshold amount, the threshold amount will be increased by $900. If a <ref target="1013-2-e-1" reftype="term">consumer lease</ref> is exempt from the requirements of this part because the total contractual obligation exceeds the threshold amount in effect at the time of consummation, the <ref target="1013-2-e-1" reftype="term">lease</ref> remains exempt regardless of a subsequent increase in the threshold amount.</content>
+      </interpParagraph>
+    <interpParagraph label="1013-2-e-Interp-10" marker="10." target="1013-2-e-10">
+        <title type="keyterm">No increase in the CPI-W.</title>
+        <content>If the CPI-W in effect on June 1 does not increase from the CPI-W in effect on June 1 of the previous year, the threshold amount effective the following January 1 through December 31 will not change from the previous year. When this occurs, for the years that follow, the threshold is calculated based on the annual percentage change in the CPI-W applied to the dollar amount that would have resulted, after rounding, if decreases and any subsequent increases in the CPI-W had been taken into account.</content>
+      <interpParagraph label="1013-2-e-Interp-10-i" marker="i.">
+        <title type="keyterm">Net increases.</title>
+        <content>If the resulting amount calculated, after rounding, is greater than the current threshold, then the threshold effective January 1 the following year will increase accordingly.</content>
+      </interpParagraph>
+    <interpParagraph label="1013-2-e-Interp-10-ii" marker="ii.">
+        <title type="keyterm">Net decreases.</title>
+        <content>If the resulting amount calculated, after rounding, is equal to or less than the current threshold, then the threshold effective January 1 the following year will not change, but future increases will be calculated based on the amount that would have resulted.</content>
+      </interpParagraph>
+    </interpParagraph>
+    <interpParagraph label="1013-2-e-Interp-11" marker="11." target="1013-2-e-11">
+        <title type="keyterm">Threshold.</title>
+        <content>For purposes of § <ref target="1013-2-e-1" reftype="internal">1013.2(e)(1)</ref>, the threshold amount in effect during a particular period is the amount stated below for that period.</content>
+      <interpParagraph label="1013-2-e-Interp-11-i" marker="i.">
+        <content>Prior to July 21, 2011, the threshold amount is $25,000.</content>
+      </interpParagraph>
+    <interpParagraph label="1013-2-e-Interp-11-ii" marker="ii.">
+        <content>From July 21, 2011 through December 31, 2011, the threshold amount is $50,000.</content>
+      </interpParagraph>
+    <interpParagraph label="1013-2-e-Interp-11-iii" marker="iii.">
+        <content>From January 1, 2012 through December 31, 2012, the threshold amount is $51,800.</content>
+      </interpParagraph>
+    <interpParagraph label="1013-2-e-Interp-11-iv" marker="iv.">
+        <content>From January 1, 2013 through December 31, 2013, the threshold amount is $53,000.</content>
+      </interpParagraph>
+    <interpParagraph label="1013-2-e-Interp-11-v" marker="v.">
+        <content>From January 1, 2014 through December 31, 2014, the threshold amount is $53,500.</content>
+      </interpParagraph>
+    <interpParagraph label="1013-2-e-Interp-11-vi" marker="vi.">
+        <content>From January 1, 2015 through December 31, 2015, the threshold amount is $54,600.</content>
+      </interpParagraph>
+    <interpParagraph label="1013-2-e-Interp-11-vii" marker="vii.">
+        <content>From January 1, 2016 through December 31, 2016, the threshold amount is $54,600.</content>
+      </interpParagraph>
+    <interpParagraph label="1013-2-e-Interp-11-viii" marker="viii.">
+        <content>From January 1, 2017 through December 31, 2017, the threshold amount is $54,600.</content>
+      </interpParagraph>
+    <interpParagraph label="1013-2-e-Interp-11-ix" marker="ix.">
+        <content>From January 1, 2018 through December 31, 2018, the threshold amount is $55,800.</content>
+      </interpParagraph>
+    </interpParagraph>
+    </interpParagraph>
+          <interpParagraph label="1013-2-g-Interp" target="1013-2-g">
+            <title>2(g) Lessee</title>
+            <content/>
+            <interpParagraph label="1013-2-g-Interp-1" marker="1.">
+              <title type="keyterm">Guarantors.</title>
+              <content>Guarantors are not <ref target="1013-2-g" reftype="term">lessees</ref> for purposes of the regulation.</content>
+            </interpParagraph>
+          </interpParagraph>
+          <interpParagraph label="1013-2-h-Interp" target="1013-2-h">
+            <title>2(h) Lessor</title>
+            <content/>
+            <interpParagraph label="1013-2-h-Interp-1" marker="1.">
+              <title type="keyterm">Arranger of a lease.</title>
+              <content>To “arrange” for the <ref target="1013-2-e-1" reftype="term">lease</ref> of <ref target="1013-2-l" reftype="term">personal property</ref> means to provide or offer to provide a <ref target="1013-2-e-1" reftype="term">lease</ref> that is or will be extended by another <ref target="1013-2-k" reftype="term">person</ref> under a business or other relationship pursuant to which the <ref target="1013-2-k" reftype="term">person</ref> arranging the <ref target="1013-2-e-1" reftype="term">lease</ref> (a) receives or will receive a fee, compensation, or other consideration for the service or (b) has knowledge of the <ref target="1013-2-e-1" reftype="term">lease</ref> terms and participates in the preparation of the contract documents required in connection with the <ref target="1013-2-e-1" reftype="term">lease</ref>. To illustrate:</content>
+              <interpParagraph label="1013-2-h-Interp-1-i" marker="i.">
+                <content>An entity that, pursuant to a business relationship, completes the necessary <ref target="1013-2-e-1" reftype="term">lease</ref> agreement before forwarding it for execution to the leasing company (to whom the obligation is payable on its face) is “arranging” for the <ref target="1013-2-e-1" reftype="term">lease</ref>.</content>
+              </interpParagraph>
+              <interpParagraph label="1013-2-h-Interp-1-ii" marker="ii.">
+                <content>An entity that, without receiving a fee for the service, refers a customer to a leasing company that will prepare all relevant contract documents is not “arranging” for the <ref target="1013-2-e-1" reftype="term">lease</ref>.</content>
+              </interpParagraph>
+            </interpParagraph>
+            <interpParagraph label="1013-2-h-Interp-2" marker="2.">
+              <title type="keyterm">Consideration.</title>
+              <content>The term “other consideration” as used in comment <ref target="1013-2-h-Interp-1" reftype="internal">2(h)-1</ref> refers to an actual payment corresponding to a fee or similar compensation and not to intangible benefits, such as the advantage of increased business, which may flow from the relationship between the parties.</content>
+            </interpParagraph>
+            <interpParagraph label="1013-2-h-Interp-3" marker="3.">
+              <title type="keyterm">Assignees.</title>
+              <content>An assignee may be a <ref target="1013-2-h" reftype="term">lessor</ref> for purposes of the regulation in circumstances where the assignee has substantial involvement in the <ref target="1013-2-e-1" reftype="term">lease</ref> transaction. See cf. Ford Motor Credit Co. v. Cenance, 452 U.S. 155 (1981) (held that an assignee was a creditor for purposes of the pre-1980 Truth in Lending Act and Regulation Z because of its substantial involvement in the credit transaction).</content>
+            </interpParagraph>
+            <interpParagraph label="1013-2-h-Interp-4" marker="4.">
+              <title type="keyterm">Multiple lessors.</title>
+              <content>See the commentary to § <ref target="1013-3-c-Interp" reftype="internal">1013.3(c)</ref>.</content>
+            </interpParagraph>
+          </interpParagraph>
+          <interpParagraph label="1013-2-j-Interp" target="1013-2-j">
+            <title>2(j) Organization</title>
+            <content/>
+            <interpParagraph label="1013-2-j-Interp-1" marker="1.">
+              <title type="keyterm">Coverage.</title>
+              <content>The term “<ref target="1013-2-j" reftype="term">organization</ref>” includes joint ventures and <ref target="1013-2-k" reftype="term">persons</ref> operating under a business name.</content>
+            </interpParagraph>
+          </interpParagraph>
+          <interpParagraph label="1013-2-l-Interp" target="1013-2-l">
+            <title>2(l) Personal Property</title>
+            <content/>
+            <interpParagraph label="1013-2-l-Interp-1" marker="1.">
+              <title type="keyterm">Coverage.</title>
+              <content>Whether property is <ref target="1013-2-l" reftype="term">personal property</ref> depends on <ref target="1013-2-p" reftype="term">state</ref> or other applicable law. For example, a mobile home or houseboat may be considered <ref target="1013-2-l" reftype="term">personal property</ref> in one <ref target="1013-2-p" reftype="term">state</ref> but real property in another.</content>
+            </interpParagraph>
+          </interpParagraph>
+          <interpParagraph label="1013-2-m-Interp" target="1013-2-m">
+            <title>2(m) Realized Value</title>
+            <content/>
+            <interpParagraph label="1013-2-m-Interp-1" marker="1.">
+              <title type="keyterm">General.</title>
+              <content><ref target="1013-2-m" reftype="term">Realized value</ref> refers to either the retail or wholesale value of the leased property at early termination or at the end of the <ref target="1013-2-e-1" reftype="term">lease</ref> term. It is not a required disclosure. <ref target="1013-2-m" reftype="term">Realized value</ref> is relevant only to <ref target="1013-2-e-1" reftype="term">leases</ref> in which the <ref target="1013-2-g" reftype="term">lessee</ref>'s liability at early termination or at the end of the <ref target="1013-2-e-1" reftype="term">lease</ref> term typically is based on the difference between the <ref target="1013-2-n" reftype="term">residual value</ref> (or the adjusted <ref target="1013-2-e-1" reftype="term">lease</ref> balance) of the leased property and its <ref target="1013-2-m" reftype="term">realized value</ref>.</content>
+            </interpParagraph>
+            <interpParagraph label="1013-2-m-Interp-2" marker="2.">
+              <title type="keyterm">Options.</title>
+              <content>Subject to the contract and to <ref target="1013-2-p" reftype="term">state</ref> or other applicable law, the <ref target="1013-2-h" reftype="term">lessor</ref> may calculate the <ref target="1013-2-m" reftype="term">realized value</ref> in determining the <ref target="1013-2-g" reftype="term">lessee</ref>'s liability at the end of the <ref target="1013-2-e-1" reftype="term">lease</ref> term or at early termination in one of the three ways stated in § <ref target="1013-2-m" reftype="internal">1013.2(m)</ref>. If the <ref target="1013-2-h" reftype="term">lessor</ref> sells the property prior to making the determination about liability, the price received for the property (or the fair market value) is the <ref target="1013-2-m" reftype="term">realized value</ref>. If the <ref target="1013-2-h" reftype="term">lessor</ref> does not sell the property prior to making that determination, the highest offer or the fair market value is the <ref target="1013-2-m" reftype="term">realized value</ref>.</content>
+            </interpParagraph>
+            <interpParagraph label="1013-2-m-Interp-3" marker="3.">
+              <title type="keyterm">Determination of realized value.</title>
+              <content>Disposition charges are not subtracted in determining the <ref target="1013-2-m" reftype="term">realized value</ref> but amounts attributable to taxes may be subtracted.</content>
+            </interpParagraph>
+            <interpParagraph label="1013-2-m-Interp-4" marker="4.">
+              <title type="keyterm">Offers.</title>
+              <content>In determining the highest offer for disposition, the <ref target="1013-2-h" reftype="term">lessor</ref> may disregard offers that an offeror has withdrawn or is unable or unwilling to perform.</content>
+            </interpParagraph>
+            <interpParagraph label="1013-2-m-Interp-5" marker="5.">
+              <title type="keyterm">Lessor's appraisal.</title>
+              <content>See commentary to § <ref target="1013-4-l-Interp" reftype="internal">1013.4(l)</ref>.</content>
+            </interpParagraph>
+          </interpParagraph>
+          <interpParagraph label="1013-2-o-Interp" target="1013-2-o">
+            <title>2(o) Security Interest and Security</title>
+            <content/>
+            <interpParagraph label="1013-2-o-Interp-1" marker="1.">
+              <title type="keyterm">Disclosable interests.</title>
+              <content>For purposes of disclosure, a <ref target="1013-2-o" reftype="term">security interest</ref> is an interest taken by the <ref target="1013-2-h" reftype="term">lessor</ref> to secure performance of the <ref target="1013-2-g" reftype="term">lessee</ref>'s obligation. For example, if a bank that is not a <ref target="1013-2-h" reftype="term">lessor</ref> makes a loan to a leasing company and takes assignments of <ref target="1013-2-e-1" reftype="term">consumer leases</ref> generated by that company to secure the loan, the bank's <ref target="1013-2-o" reftype="term">security interest</ref> in the <ref target="1013-2-h" reftype="term">lessor</ref>'s receivables is not a <ref target="1013-2-o" reftype="term">security interest</ref> for purposes of this part.</content>
+            </interpParagraph>
+            <interpParagraph label="1013-2-o-Interp-2" marker="2.">
+              <title type="keyterm">General coverage.</title>
+              <content>An interest the <ref target="1013-2-h" reftype="term">lessor</ref> may have in leased property must be disclosed only if it is considered a <ref target="1013-2-o" reftype="term">security interest</ref> under <ref target="1013-2-p" reftype="term">state</ref> or other applicable law. The term includes, but is not limited to, <ref target="1013-2-o" reftype="term">security interests</ref> under the Uniform Commercial Code; real property mortgages, deeds of trust, and other consensual or confessed liens whether or not recorded; mechanic's, materialman's, artisan's, and other similar liens; vendor's liens in both real and <ref target="1013-2-l" reftype="term">personal property</ref>; liens on property arising by operation of law; and any interest in a <ref target="1013-2-e-1" reftype="term">lease</ref> when used to secure payment or performance of an obligation.</content>
+            </interpParagraph>
+            <interpParagraph label="1013-2-o-Interp-3" marker="3.">
+              <title type="keyterm">Insurance exception.</title>
+              <content>The <ref target="1013-2-h" reftype="term">lessor</ref>'s right to insurance proceeds or unearned insurance premiums is not a <ref target="1013-2-o" reftype="term">security interest</ref> for purposes of this part.</content>
+            </interpParagraph>
+          </interpParagraph>
+        </interpSection>
+        <interpSection label="1013-3-Interp" sectionNum="3">
+          <title>Section 1013.3—General Disclosure Requirements</title>
+          <interpParagraph label="1013-3-a-Interp" target="1013-3-a">
+            <title>3(a) General Requirements</title>
+            <content/>
+            <interpParagraph label="1013-3-a-Interp-1" marker="1.">
+              <title type="keyterm">Basis of disclosures.</title>
+              <content>Disclosures must reflect the terms of the legal obligation between the parties. For example:</content>
+              <interpParagraph label="1013-3-a-Interp-1-i" marker="i.">
+                <content>In a three-year <ref target="1013-2-e-1" reftype="term">lease</ref> with no penalty for termination after a one-year minimum term, disclosures are based on the full three-year term of the <ref target="1013-2-e-1" reftype="term">lease</ref>. The one-year minimum term is only relevant to the early termination provisions of §§ <ref target="1013-4-g-1" reftype="internal">1013.4 (g)(1)</ref>, <ref target="1013-4-k" reftype="internal">(k)</ref> and <ref target="1013-4-l" reftype="internal">(l)</ref>.</content>
+              </interpParagraph>
+            </interpParagraph>
+            <interpParagraph label="1013-3-a-Interp-2" marker="2.">
+              <title type="keyterm">Clear and conspicuous standard.</title>
+              <content>The clear and conspicuous standard requires that disclosures be reasonably understandable. For example, the disclosures must be presented in a way that does not obscure the relationship of the terms to each other; Appendix <ref target="1013-A" reftype="internal">A</ref> of this part contains model forms that meet this standard. In addition, although no minimum typesize is required, the disclosures must be legible, whether typewritten, handwritten, or printed by computer.</content>
+            </interpParagraph>
+            <interpParagraph label="1013-3-a-Interp-3" marker="3.">
+              <title type="keyterm">Multipurpose disclosure forms.</title>
+              <content>A <ref target="1013-2-h" reftype="term">lessor</ref> may use a multipurpose disclosure form provided the <ref target="1013-2-h" reftype="term">lessor</ref> is able to designate the specific disclosures applicable to a given transaction, consistent with the requirement that disclosures be clearly and conspicuously provided.</content>
+            </interpParagraph>
+            <interpParagraph label="1013-3-a-Interp-4" marker="4.">
+              <title type="keyterm">Number of transactions.</title>
+              <content><ref target="1013-2-h" reftype="term">Lessors</ref> have flexibility in handling <ref target="1013-2-e-1" reftype="term">lease</ref> transactions that may be viewed as multiple transactions. For example:</content>
+              <interpParagraph label="1013-3-a-Interp-4-i" marker="i.">
+                <content>When a <ref target="1013-2-h" reftype="term">lessor</ref> <ref target="1013-2-e-1" reftype="term">leases</ref> two items to the same <ref target="1013-2-g" reftype="term">lessee</ref> on the same day, the <ref target="1013-2-h" reftype="term">lessor</ref> may disclose the <ref target="1013-2-e-1" reftype="term">leases</ref> as either one or two <ref target="1013-2-e-1" reftype="term">lease</ref> transactions.</content>
+              </interpParagraph>
+              <interpParagraph label="1013-3-a-Interp-4-ii" marker="ii.">
+                <content>When a <ref target="1013-2-h" reftype="term">lessor</ref> sells insurance or other incidental services in connection with a <ref target="1013-2-e-1" reftype="term">lease</ref>, the <ref target="1013-2-h" reftype="term">lessor</ref> may disclose in one of two ways: As a single <ref target="1013-2-e-1" reftype="term">lease</ref> transaction (in which case Regulation M, not Regulation Z, disclosures are required) or as a <ref target="1013-2-e-1" reftype="term">lease</ref> transaction and a credit transaction.</content>
+              </interpParagraph>
+              <interpParagraph label="1013-3-a-Interp-4-iii" marker="iii.">
+                <content>When a <ref target="1013-2-h" reftype="term">lessor</ref> includes an outstanding <ref target="1013-2-e-1" reftype="term">lease</ref> or credit balance in a <ref target="1013-2-e-1" reftype="term">lease</ref> transaction, the <ref target="1013-2-h" reftype="term">lessor</ref> may disclose the outstanding balance as part of a single <ref target="1013-2-e-1" reftype="term">lease</ref> transaction (in which case Regulation M, not Regulation Z, disclosures are required) or as a <ref target="1013-2-e-1" reftype="term">lease</ref> transaction and a credit transaction.</content>
+              </interpParagraph>
+            </interpParagraph>
+            <interpParagraph label="1013-3-a-1-Interp" target="1013-3-a-1">
+              <title>3(a)(1) Form of Disclosures</title>
+              <content/>
+              <interpParagraph label="1013-3-a-1-Interp-1" marker="1.">
+                <title type="keyterm">Cross-references.</title>
+                <content><ref target="1013-2-h" reftype="term">Lessors</ref> may include in the nonsegregated disclosures a cross-reference to items in the segregated disclosures rather than repeat those items. A <ref target="1013-2-h" reftype="term">lessor</ref> may include in the segregated disclosures numeric or alphabetic designations as cross-references to related information so long as such references do not obscure or detract from the segregated disclosures.</content>
+              </interpParagraph>
+              <interpParagraph label="1013-3-a-1-Interp-2" marker="2.">
+                <title type="keyterm">Identification of parties.</title>
+                <content>While disclosures must be made clearly and conspicuously, <ref target="1013-2-h" reftype="term">lessors</ref> are not required to use the word “<ref target="1013-2-h" reftype="term">lessor</ref>” and “<ref target="1013-2-g" reftype="term">lessee</ref>” to identify the parties to the <ref target="1013-2-e-1" reftype="term">lease</ref> transaction.</content>
+              </interpParagraph>
+              <interpParagraph label="1013-3-a-1-Interp-3" marker="3.">
+                <title type="keyterm">Lessor's address.</title>
+                <content>The <ref target="1013-2-h" reftype="term">lessor</ref> must be identified by name; an address (and telephone number) may be provided.</content>
+              </interpParagraph>
+              <interpParagraph label="1013-3-a-1-Interp-4" marker="4.">
+                <title type="keyterm">Multiple lessors and lessees.</title>
+                <content>In transactions involving multiple <ref target="1013-2-h" reftype="term">lessors</ref> and multiple <ref target="1013-2-g" reftype="term">lessees</ref>, a single <ref target="1013-2-h" reftype="term">lessor</ref> may make all the disclosures to a single <ref target="1013-2-g" reftype="term">lessee</ref> as long as the disclosure statement identifies all the <ref target="1013-2-h" reftype="term">lessors</ref> and <ref target="1013-2-g" reftype="term">lessees</ref>.</content>
+              </interpParagraph>
+              <interpParagraph label="1013-3-a-1-Interp-5" marker="5.">
+                <title type="keyterm">Lessee's signature.</title>
+                <content>The regulation does not require that the <ref target="1013-2-g" reftype="term">lessee</ref> sign the disclosure statement, whether disclosures are separately provided or are part of the <ref target="1013-2-e-1" reftype="term">lease</ref> contract. Nevertheless, to provide evidence that disclosures are given before a <ref target="1013-2-g" reftype="term">lessee</ref> becomes obligated on the <ref target="1013-2-e-1" reftype="term">lease</ref> transaction, the <ref target="1013-2-h" reftype="term">lessor</ref> may, for example, ask the <ref target="1013-2-g" reftype="term">lessee</ref> to sign the disclosure statement or an acknowledgement of receipt, may place disclosures that are included in the <ref target="1013-2-e-1" reftype="term">lease</ref> documents above the <ref target="1013-2-g" reftype="term">lessee</ref>'s signature, or include instructions alerting a <ref target="1013-2-g" reftype="term">lessee</ref> to read the disclosures prior to signing the <ref target="1013-2-e-1" reftype="term">lease</ref>.</content>
+              </interpParagraph>
+            </interpParagraph>
+            <interpParagraph label="1013-3-a-2-Interp" target="1013-3-a-2">
+              <title>3(a)(2) Segregation of Certain Disclosures</title>
+              <content/>
+              <interpParagraph label="1013-3-a-2-Interp-1" marker="1.">
+                <title type="keyterm">Location.</title>
+                <content>The segregated disclosures referred to in § <ref target="1013-3-a-2" reftype="internal">1013.3(a)(2)</ref> may be provided on a separate document and the other required disclosures may be provided in the <ref target="1013-2-e-1" reftype="term">lease</ref> contract, so long as all disclosures are given at the same time. Alternatively, all disclosures may be provided in a separate document or in the <ref target="1013-2-e-1" reftype="term">lease</ref> contract.</content>
+              </interpParagraph>
+              <interpParagraph label="1013-3-a-2-Interp-2" marker="2.">
+                <title type="keyterm">Additional information among segregated disclosures.</title>
+                <content>The disclosures required to be segregated may contain only the information required or permitted to be included among the segregated disclosures.</content>
+              </interpParagraph>
+              <interpParagraph label="1013-3-a-2-Interp-3" marker="3.">
+                <title type="keyterm">Substantially similar.</title>
+                <content>See commentary to Appendix <ref target="1013-A" reftype="internal">A</ref> of this part.</content>
+              </interpParagraph>
+            </interpParagraph>
+            <interpParagraph label="1013-3-a-3-Interp" target="1013-3-a-3">
+              <title>3(a)(3) Timing of Disclosures</title>
+              <content/>
+              <interpParagraph label="1013-3-a-3-Interp-1" marker="1.">
+                <title type="keyterm">Consummation.</title>
+                <content>When a contractual relationship is created between the <ref target="1013-2-h" reftype="term">lessor</ref> and the <ref target="1013-2-g" reftype="term">lessee</ref> is a matter to be determined under <ref target="1013-2-p" reftype="term">state</ref> or other applicable law.</content>
+              </interpParagraph>
+            </interpParagraph>
+          </interpParagraph>
+          <interpParagraph label="1013-3-b-Interp" target="1013-3-b">
+            <title>3(b) Additional Information; Nonsegregated Disclosures</title>
+            <content/>
+            <interpParagraph label="1013-3-b-Interp-1" marker="1.">
+              <title type="keyterm">State law disclosures.</title>
+              <content>A <ref target="1013-2-h" reftype="term">lessor</ref> may include in the nonsegregated disclosures any <ref target="1013-2-p" reftype="term">state</ref> law disclosures that are not inconsistent with the <ref target="1013-2-a" reftype="term">Act</ref> and regulation under § <ref target="1013-9" reftype="internal">1013.9</ref> as long as, in accordance with the standard set forth in § <ref target="1013-3-b" reftype="internal">1013.3(b)</ref> for additional information, the <ref target="1013-2-p" reftype="term">state</ref> law disclosures are not used or placed to mislead or confuse or detract from any disclosure required by the regulation.</content>
+            </interpParagraph>
+          </interpParagraph>
+          <interpParagraph label="1013-3-c-Interp" target="1013-3-c">
+            <title>3(c) Multiple Lessors or Lessees</title>
+            <content/>
+            <interpParagraph label="1013-3-c-Interp-1" marker="1.">
+              <title type="keyterm">Multiple lessors.</title>
+              <content>If a single <ref target="1013-2-h" reftype="term">lessor</ref> provides disclosures to a <ref target="1013-2-g" reftype="term">lessee</ref> on behalf of several <ref target="1013-2-h" reftype="term">lessors</ref>, all disclosures for the transaction must be given, even if the <ref target="1013-2-h" reftype="term">lessor</ref> making the disclosures would not otherwise have been obligated to make a particular disclosure.</content>
+            </interpParagraph>
+          </interpParagraph>
+          <interpParagraph label="1013-3-d-Interp" target="1013-3-d">
+            <title>3(d) Use of Estimates</title>
+            <content/>
+            <interpParagraph label="1013-3-d-Interp-1" marker="1.">
+              <title type="keyterm">Time of estimated disclosure.</title>
+              <content>The <ref target="1013-2-h" reftype="term">lessor</ref> may, after making a reasonable effort to obtain information, use estimates to make disclosures if necessary information is unknown or unavailable at the time the disclosures are made.</content>
+            </interpParagraph>
+            <interpParagraph label="1013-3-d-Interp-2" marker="2.">
+              <title type="keyterm">Basis of estimates.</title>
+              <content>Estimates must be made on the basis of the best information reasonably available at the time disclosures are made. The “reasonably available” standard requires that the <ref target="1013-2-h" reftype="term">lessor</ref>, acting in good faith, exercise due diligence in obtaining information. The <ref target="1013-2-h" reftype="term">lessor</ref> may rely on the representations of other parties. For example, the <ref target="1013-2-h" reftype="term">lessor</ref> might look to the consumer to determine the purpose for which leased property will be used, to insurance companies for the cost of insurance, or to an automobile manufacturer or dealer for the date of delivery. See commentary to § <ref target="1013-4-n-Interp" reftype="internal">1013.4(n)</ref> for estimating official fees and taxes.</content>
+            </interpParagraph>
+            <interpParagraph label="1013-3-d-Interp-3" marker="3.">
+              <title type="keyterm">Residual value of leased property at termination.</title>
+              <content>In an <ref target="1013-2-i" reftype="term">open-end lease</ref> where the <ref target="1013-2-g" reftype="term">lessee</ref>'s liability at the end of the <ref target="1013-2-e-1" reftype="term">lease</ref> term is based on the <ref target="1013-2-n" reftype="term">residual value</ref> of the leased property as determined at consummation, the estimate of the <ref target="1013-2-n" reftype="term">residual value</ref> must be reasonable and based on the best information reasonably available to the <ref target="1013-2-h" reftype="term">lessor</ref> (see § <ref target="1013-4-m" reftype="internal">1013.4(m)</ref>). A <ref target="1013-2-h" reftype="term">lessor</ref> should generally use an accepted trade publication listing estimated current or future market prices for the leased property unless other information or a reasonable belief based on its experience provides the better information. For example:</content>
+              <interpParagraph label="1013-3-d-Interp-3-i" marker="i.">
+                <content>An automobile <ref target="1013-2-h" reftype="term">lessor</ref> offering a three-year <ref target="1013-2-i" reftype="term">open-end lease</ref> assigns a wholesale value to the vehicle at the end of the <ref target="1013-2-e-1" reftype="term">lease</ref> term. The <ref target="1013-2-h" reftype="term">lessor</ref> may disclose as an estimate a wholesale value derived from a generally accepted trade publication listing current wholesale values.</content>
+              </interpParagraph>
+              <interpParagraph label="1013-3-d-Interp-3-ii" marker="ii.">
+                <content>Same facts as above, except that the <ref target="1013-2-h" reftype="term">lessor</ref> discloses an estimated value derived by adjusting the <ref target="1013-2-n" reftype="term">residual value</ref> quoted in the trade publication because, in its experience, the trade publication values either understate or overstate the prices actually received in local used vehicle markets. The <ref target="1013-2-h" reftype="term">lessor</ref> may adjust estimated values quoted in trade publications if the <ref target="1013-2-h" reftype="term">lessor</ref> reasonably believes based on its experience that the values are understated or overstated.</content>
+              </interpParagraph>
+            </interpParagraph>
+            <interpParagraph label="1013-3-d-Interp-4" marker="4.">
+              <title type="keyterm">Retail or wholesale value.</title>
+              <content>The <ref target="1013-2-h" reftype="term">lessor</ref> may choose either a retail or a wholesale value in estimating the value of leased property at termination of an <ref target="1013-2-i" reftype="term">open-end lease</ref> provided the choice is consistent with the <ref target="1013-2-h" reftype="term">lessor</ref>'s general practice when determining the value of the property at the end of the <ref target="1013-2-e-1" reftype="term">lease</ref> term. The <ref target="1013-2-h" reftype="term">lessor</ref> should indicate whether the value disclosed is a retail or wholesale value.</content>
+            </interpParagraph>
+            <interpParagraph label="1013-3-d-Interp-5" marker="5.">
+              <title type="keyterm">Labeling estimates.</title>
+              <content>Generally, only the disclosure for which the exact information is unknown is labeled as an estimate. Nevertheless, when several disclosures are affected because of the unknown information, the <ref target="1013-2-h" reftype="term">lessor</ref> has the option of labeling as an estimate every affected disclosure or only the disclosure primarily affected.</content>
+            </interpParagraph>
+          </interpParagraph>
+          <interpParagraph label="1013-3-e-Interp" target="1013-3-e">
+            <title>3(e) Effect of Subsequent Occurrence</title>
+            <content/>
+            <interpParagraph label="1013-3-e-Interp-1" marker="1.">
+              <title type="keyterm">Subsequent occurrences.</title>
+              <content>Examples of subsequent occurrences include:</content>
+              <interpParagraph label="1013-3-e-Interp-1-i" marker="i.">
+                <content>An agreement between the <ref target="1013-2-g" reftype="term">lessee</ref> and <ref target="1013-2-h" reftype="term">lessor</ref> to change from a monthly to a weekly payment schedule.</content>
+              </interpParagraph>
+              <interpParagraph label="1013-3-e-Interp-1-ii" marker="ii.">
+                <content>An increase in official fees or taxes.</content>
+              </interpParagraph>
+              <interpParagraph label="1013-3-e-Interp-1-iii" marker="iii.">
+                <content>An increase in insurance premiums or coverage caused by a change in the law.</content>
+              </interpParagraph>
+              <interpParagraph label="1013-3-e-Interp-1-iv" marker="iv.">
+                <content>Late delivery of an automobile caused by a strike.</content>
+              </interpParagraph>
+            </interpParagraph>
+            <interpParagraph label="1013-3-e-Interp-2" marker="2.">
+              <title type="keyterm">Redisclosure.</title>
+              <content>When a disclosure becomes inaccurate because of a subsequent occurrence, the <ref target="1013-2-h" reftype="term">lessor</ref> need not make new disclosures unless new disclosures are required under § <ref target="1013-5" reftype="internal">1013.5</ref>.</content>
+            </interpParagraph>
+            <interpParagraph label="1013-3-e-Interp-3" marker="3.">
+              <title type="keyterm">Lessee's failure to perform.</title>
+              <content>The <ref target="1013-2-h" reftype="term">lessor</ref> does not violate the regulation if a previously given disclosure becomes inaccurate when a <ref target="1013-2-g" reftype="term">lessee</ref> fails to perform obligations under the contract and a <ref target="1013-2-h" reftype="term">lessor</ref> takes actions that are necessary and proper in such circumstances to protect its interest. For example, the addition of insurance or a <ref target="1013-2-o" reftype="term">security interest</ref> by the <ref target="1013-2-h" reftype="term">lessor</ref> because the <ref target="1013-2-g" reftype="term">lessee</ref> has not performed obligations contracted for in the <ref target="1013-2-e-1" reftype="term">lease</ref> is not a violation of the regulation.</content>
+            </interpParagraph>
+          </interpParagraph>
+        </interpSection>
+        <interpSection label="1013-4-Interp" sectionNum="4">
+          <title>Section 1013.4—Content of Disclosures</title>
+          <interpParagraph label="1013-4-a-Interp" target="1013-4-a">
+            <title>4(a) Description of Property</title>
+            <content/>
+            <interpParagraph label="1013-4-a-Interp-1" marker="1.">
+              <title type="keyterm">Placement of description.</title>
+              <content>Although the description of leased property may not be included among the segregated disclosures, a <ref target="1013-2-h" reftype="term">lessor</ref> may choose to place the description directly above the segregated disclosures.</content>
+            </interpParagraph>
+          </interpParagraph>
+          <interpParagraph label="1013-4-b-Interp" target="1013-4-b">
+            <title>4(b) Amount Due at Lease Signing or Delivery</title>
+            <content/>
+            <interpParagraph label="1013-4-b-Interp-1" marker="1.">
+              <title type="keyterm">Consummation.</title>
+              <content>See commentary to § <ref target="1013-3-a-3-Interp" reftype="internal">1013.3(a)(3)</ref>.</content>
+            </interpParagraph>
+            <interpParagraph label="1013-4-b-Interp-2" marker="2.">
+              <title type="keyterm">Capitalized cost reduction.</title>
+              <content>A capitalized cost reduction is a payment in the nature of a downpayment on the leased property that reduces the amount to be capitalized over the term of the <ref target="1013-2-e-1" reftype="term">lease</ref>. This amount does not include any amounts included in a periodic payment paid at <ref target="1013-2-e-1" reftype="term">lease</ref> signing or delivery.</content>
+            </interpParagraph>
+            <interpParagraph label="1013-4-b-Interp-3" marker="3.">
+              <title type="keyterm">“Negative” equity trade-in allowance.</title>
+              <content>If an amount owed on a prior <ref target="1013-2-e-1" reftype="term">lease</ref> or credit balance exceeds the agreed upon value of a trade-in, the difference is not reflected as a negative trade-in allowance under § <ref target="1013-4-b" reftype="internal">1013.4(b)</ref>. The <ref target="1013-2-h" reftype="term">lessor</ref> may disclose the trade-in allowance as zero or not applicable, or may leave a blank line.</content>
+            </interpParagraph>
+            <interpParagraph label="1013-4-b-Interp-4" marker="4.">
+              <title type="keyterm">Rebates.</title>
+              <content>Only rebates applied toward an amount due at <ref target="1013-2-e-1" reftype="term">lease</ref> signing or delivery are required to be disclosed under § <ref target="1013-4-b" reftype="internal">1013.4(b)</ref>.</content>
+            </interpParagraph>
+            <interpParagraph label="1013-4-b-Interp-5" marker="5.">
+              <title type="keyterm">Balance sheet approach.</title>
+              <content>In motor vehicle <ref target="1013-2-e-1" reftype="term">leases</ref>, the total for the column labeled “total amount due at <ref target="1013-2-e-1" reftype="term">lease</ref> signing or delivery” must equal the total for the column labeled “how the amount due at <ref target="1013-2-e-1" reftype="term">lease</ref> signing or delivery will be paid.”</content>
+            </interpParagraph>
+            <interpParagraph label="1013-4-b-Interp-6" marker="6.">
+              <title type="keyterm">Amounts to be paid in cash.</title>
+              <content>The term cash is intended to include payments by check or other payment methods in addition to currency; however, a <ref target="1013-2-h" reftype="term">lessor</ref> may add a line item under the column “how the amount due at <ref target="1013-2-e-1" reftype="term">lease</ref> signing or delivery will be paid” for non-currency payments such as credit cards.</content>
+            </interpParagraph>
+          </interpParagraph>
+          <interpParagraph label="1013-4-c-Interp" target="1013-4-c">
+            <title>4(c) Payment Schedule and Total Amount of Periodic Payments</title>
+            <content/>
+            <interpParagraph label="1013-4-c-Interp-1" marker="1.">
+              <title type="keyterm">Periodic payments.</title>
+              <content>The phrase “number, amount, and due dates or periods of payments” requires the disclosure of all payments that are made at regular or irregular intervals and generally derived from rent, capitalized or amortized amounts such as depreciation, and other amounts that are collected by the <ref target="1013-2-h" reftype="term">lessor</ref> at the same interval(s), including, for example, taxes, maintenance, and insurance charges. Other periodic payments may, but need not, be disclosed under § <ref target="1013-4-c" reftype="internal">1013.4(c)</ref>.</content>
+            </interpParagraph>
+          </interpParagraph>
+          <interpParagraph label="1013-4-d-Interp" target="1013-4-d">
+            <title>4(d) Other Charges</title>
+            <content/>
+            <interpParagraph label="1013-4-d-Interp-1" marker="1.">
+              <title type="keyterm">Coverage.</title>
+              <content>Section <ref target="1013-4-d" reftype="internal">1013.4(d)</ref> requires the disclosure of charges that are anticipated by the parties incident to the normal operation of the <ref target="1013-2-e-1" reftype="term">lease</ref> agreement. If a <ref target="1013-2-h" reftype="term">lessor</ref> is unsure whether a particular fee is an “other charge,” the <ref target="1013-2-h" reftype="term">lessor</ref> may disclose the fee as such without violating § <ref target="1013-4-d" reftype="internal">1013.4(d)</ref> or the segregation rule under § <ref target="1013-3-a-2" reftype="internal">1013.3(a)(2)</ref>.</content>
+            </interpParagraph>
+            <interpParagraph label="1013-4-d-Interp-2" marker="2.">
+              <title type="keyterm">Excluded charges.</title>
+              <content>This section does not require disclosure of charges that are imposed when the <ref target="1013-2-g" reftype="term">lessee</ref> terminates early, fails to abide by, or modifies the terms of the existing <ref target="1013-2-e-1" reftype="term">lease</ref> agreement, such as charges for:</content>
+              <interpParagraph label="1013-4-d-Interp-2-i" marker="i.">
+                <content>Late payment.</content>
+              </interpParagraph>
+              <interpParagraph label="1013-4-d-Interp-2-ii" marker="ii.">
+                <content>Default.</content>
+              </interpParagraph>
+              <interpParagraph label="1013-4-d-Interp-2-iii" marker="iii.">
+                <content>Early termination.</content>
+              </interpParagraph>
+              <interpParagraph label="1013-4-d-Interp-2-iv" marker="iv.">
+                <content>Deferral of payments.</content>
+              </interpParagraph>
+              <interpParagraph label="1013-4-d-Interp-2-v" marker="v.">
+                <content>Extension of the <ref target="1013-2-e-1" reftype="term">lease</ref>.</content>
+              </interpParagraph>
+            </interpParagraph>
+            <interpParagraph label="1013-4-d-Interp-3" marker="3.">
+              <title type="keyterm">Third-party fees and charges.</title>
+              <content>Third-party fees or charges collected by the <ref target="1013-2-h" reftype="term">lessor</ref> on behalf of third parties, such as taxes, are not disclosed under § <ref target="1013-4-d" reftype="internal">1013.4(d)</ref>.</content>
+            </interpParagraph>
+            <interpParagraph label="1013-4-d-Interp-4" marker="4.">
+              <title type="keyterm">Relationship to other provisions.</title>
+              <content>The other charges mentioned in this paragraph are charges that are not required to be disclosed under some other provision of § <ref target="1013-4" reftype="internal">1013.4</ref>. To illustrate:</content>
+              <interpParagraph label="1013-4-d-Interp-4-i" marker="i.">
+                <content>The price of a mechanical breakdown protection (MBP) contract is sometimes disclosed as an “other charge.” Nevertheless, the price of MBP is sometimes reflected in the periodic payment disclosure under § <ref target="1013-4-c" reftype="internal">1013.4(c)</ref> or in <ref target="1013-2-p" reftype="term">states</ref> where MBP is regarded as insurance, the cost is be disclosed in accordance with § <ref target="1013-4-o" reftype="internal">1013.4(o)</ref>.</content>
+              </interpParagraph>
+            </interpParagraph>
+            <interpParagraph label="1013-4-d-Interp-5" marker="5.">
+              <title type="keyterm">Lessee's liabilities at the end of the lease term.</title>
+              <content>Liabilities that the <ref target="1013-2-h" reftype="term">lessor</ref> imposes upon the <ref target="1013-2-g" reftype="term">lessee</ref> at the end of the scheduled <ref target="1013-2-e-1" reftype="term">lease</ref> term and that must be disclosed under § <ref target="1013-4-d" reftype="internal">1013.4(d)</ref> include disposition and “pick-up” charges.</content>
+            </interpParagraph>
+            <interpParagraph label="1013-4-d-Interp-6" marker="6.">
+              <title type="keyterm">Optional “disposition” charges.</title>
+              <content>Disposition and similar charges that are anticipated by the parties as an incident to the normal operation of the <ref target="1013-2-e-1" reftype="term">lease</ref> agreement must be disclosed under § <ref target="1013-4-d" reftype="internal">1013.4(d)</ref>. If, under a <ref target="1013-2-e-1" reftype="term">lease</ref> agreement, a <ref target="1013-2-g" reftype="term">lessee</ref> may return leased property to various locations, and the <ref target="1013-2-h" reftype="term">lessor</ref> charges a disposition fee depending upon the location chosen, under § <ref target="1013-4-d" reftype="internal">1013.4(d)</ref>, the <ref target="1013-2-h" reftype="term">lessor</ref> must disclose the highest amount charged. In such circumstances, the <ref target="1013-2-h" reftype="term">lessor</ref> may also include a brief explanation of the fee structure in the segregated disclosure. For example, if no fee or a lower fee is imposed for returning a leased vehicle to the originating dealer as opposed to another location, that fact may be disclosed. By contrast, if the terms of the <ref target="1013-2-e-1" reftype="term">lease</ref> treat the return of the leased property to a location outside the <ref target="1013-2-h" reftype="term">lessor</ref>'s service area as a default, the fee imposed is not disclosed as an “other charge,” although it may be required to be disclosed under § <ref target="1013-4-q" reftype="internal">1013.4(q)</ref>.</content>
+            </interpParagraph>
+          </interpParagraph>
+          <interpParagraph label="1013-4-e-Interp" target="1013-4-e">
+            <title>4(e) Total of Payments</title>
+            <content/>
+            <interpParagraph label="1013-4-e-Interp-1" marker="1.">
+              <title type="keyterm">Open-end lease.</title>
+              <content>The additional statement is required under § <ref target="1013-4-e" reftype="internal">1013.4(e)</ref> for <ref target="1013-2-i" reftype="term">open-end leases</ref> because, with some limitations, a <ref target="1013-2-g" reftype="term">lessee</ref> is liable at the end of the <ref target="1013-2-e-1" reftype="term">lease</ref> term for the difference between the residual and <ref target="1013-2-m" reftype="term">realized values</ref> of the leased property.</content>
+            </interpParagraph>
+          </interpParagraph>
+          <interpParagraph label="1013-4-f-Interp" target="1013-4-f">
+            <title>4(f) Payment Calculation</title>
+            <content/>
+            <interpParagraph label="1013-4-f-Interp-1" marker="1.">
+              <title type="keyterm">Motor vehicle lease.</title>
+              <content>Whether leased property is a motor vehicle is determined by <ref target="1013-2-p" reftype="term">state</ref> or other applicable law.</content>
+            </interpParagraph>
+            <interpParagraph label="1013-4-f-Interp-2" marker="2.">
+              <title type="keyterm">Multiple items.</title>
+              <content>If a <ref target="1013-2-e-1" reftype="term">lease</ref> transaction involves multiple items of leased property, one of which is not a motor vehicle under <ref target="1013-2-p" reftype="term">state</ref> law, at their option, <ref target="1013-2-h" reftype="term">lessors</ref> may include all items in the disclosures required under § <ref target="1013-4-f" reftype="internal">1013.4(f)</ref>. See comment <ref target="1013-3-a-Interp-4" reftype="internal">3(a)-4</ref> regarding disclosure of multiple transactions.</content>
+            </interpParagraph>
+            <interpParagraph label="1013-4-f-1-Interp" target="1013-4-f-1">
+              <title>4(f)(1) Gross Capitalized Cost</title>
+              <content/>
+              <interpParagraph label="1013-4-f-1-Interp-1" marker="1.">
+                <title type="keyterm">Agreed upon value of the vehicle.</title>
+                <content>The agreed upon value of a motor vehicle includes the amount of capitalized items such as charges for vehicle accessories and options, and delivery or destination charges. The <ref target="1013-2-h" reftype="term">lessor</ref> may also include taxes and fees for title, licenses, and registration that are capitalized. Charges for service or maintenance contracts, insurance products, guaranteed automobile protection, or an outstanding balance on a prior <ref target="1013-2-e-1" reftype="term">lease</ref> or credit transaction are not included in the agreed upon value.</content>
+              </interpParagraph>
+              <interpParagraph label="1013-4-f-1-Interp-2" marker="2.">
+                <title type="keyterm">Itemization of the gross capitalized cost.</title>
+                <content>The <ref target="1013-2-h" reftype="term">lessor</ref> may choose to provide the itemization of the <ref target="1013-2-f" reftype="term">gross capitalized cost</ref> only on request or may provide the itemization as a matter of course. In the latter case, the <ref target="1013-2-h" reftype="term">lessor</ref> need not provide a statement of the <ref target="1013-2-g" reftype="term">lessee</ref>'s option to receive an itemization. The <ref target="1013-2-f" reftype="term">gross capitalized cost</ref> must be itemized by type and amount. The <ref target="1013-2-h" reftype="term">lessor</ref> may include in the itemization an identification of the items and amounts of some or all of the items contained in the agreed upon value of the vehicle. The itemization must be provided at the same time as the other disclosures required by § <ref target="1013-4" reftype="internal">1013.4</ref>, but it may not be included among the segregated disclosures.</content>
+              </interpParagraph>
+            </interpParagraph>
+            <interpParagraph label="1013-4-f-7-Interp" target="1013-4-f-7">
+              <title>4(f)(7) Total of Base Periodic Payments</title>
+              <content/>
+              <interpParagraph label="1013-4-f-7-Interp-1" marker="1.">
+                <title type="keyterm">Accuracy of disclosure.</title>
+                <content>If the periodic payment calculation under § <ref target="1013-4-f" reftype="internal">1013.4(f)</ref> has been calculated correctly, the amount disclosed under § <ref target="1013-4-f-7" reftype="internal">1013.4(f)(7)</ref>—the total of base periodic payments—is correct for disclosure purposes even if that amount differs from the base periodic payment disclosed under § <ref target="1013-4-f-9" reftype="internal">1013.4(f)(9)</ref> multiplied by the number of <ref target="1013-2-e-1" reftype="term">lease</ref> payments disclosed under § <ref target="1013-4-f-8" reftype="internal">1013.4(f)(8)</ref>, when the difference is due to rounding.</content>
+              </interpParagraph>
+            </interpParagraph>
+            <interpParagraph label="1013-4-f-8-Interp" target="1013-4-f-8">
+              <title>4(f)(8) Lease Payments</title>
+              <content/>
+              <interpParagraph label="1013-4-f-8-Interp-1" marker="1.">
+                <title type="keyterm">Lease Term.</title>
+                <content>The <ref target="1013-2-e-1" reftype="term">lease</ref> term may be disclosed among the segregated disclosures.</content>
+              </interpParagraph>
+            </interpParagraph>
+          </interpParagraph>
+          <interpParagraph label="1013-4-g-Interp">
+            <title>4(g) Early Termination</title>
+            <content/>
+            <interpParagraph label="1013-4-g-1-Interp" target="1013-4-g-1">
+              <title>4(g)(1) Conditions and Disclosure of Charges</title>
+              <content/>
+              <interpParagraph label="1013-4-g-1-Interp-1" marker="1.">
+                <title type="keyterm">Reasonableness of charges.</title>
+                <content>See the commentary to § <ref target="1013-4-q-Interp" reftype="internal">1013.4(q)</ref>.</content>
+              </interpParagraph>
+              <interpParagraph label="1013-4-g-1-Interp-2" marker="2.">
+                <title type="keyterm">Description of the method.</title>
+                <content>Section <ref target="1013-4-g-1" reftype="internal">1013.4(g)(1)</ref> requires a full description of the method of determining an early termination charge. The <ref target="1013-2-h" reftype="term">lessor</ref> should attempt to provide consumers with clear and understandable descriptions of its early termination charges. Descriptions that are full, accurate, and not intended to be misleading will comply with § <ref target="1013-4-g-1" reftype="internal">1013.4(g)(1)</ref>, even if the descriptions are complex. In providing a full description of an early termination method, a <ref target="1013-2-h" reftype="term">lessor</ref> may use the name of a generally accepted method of computing the unamortized cost portion (also known as the “adjusted <ref target="1013-2-e-1" reftype="term">lease</ref> balance”) of its early termination charges. For example, a <ref target="1013-2-h" reftype="term">lessor</ref> may state that the “constant yield” method will be utilized in obtaining the adjusted <ref target="1013-2-e-1" reftype="term">lease</ref> balance, but must specify how that figure, and any other term or figure, is used in computing the total early termination charge imposed upon the consumer. Additionally, if a <ref target="1013-2-h" reftype="term">lessor</ref> refers to a named method in this manner, the <ref target="1013-2-h" reftype="term">lessor</ref> must provide a written explanation of that method if requested by the consumer. The <ref target="1013-2-h" reftype="term">lessor</ref> has the option of providing the explanation as a matter of course in the <ref target="1013-2-e-1" reftype="term">lease</ref> documents or on a separate document.</content>
+              </interpParagraph>
+              <interpParagraph label="1013-4-g-1-Interp-3" marker="3.">
+                <title type="keyterm">Timing of written explanation of a named method.</title>
+                <content>While a <ref target="1013-2-h" reftype="term">lessor</ref> may provide an address or telephone number for the consumer to request a written explanation of the named method used to calculate the adjusted leased balance, if at consummation a consumer requests such an explanation, the <ref target="1013-2-h" reftype="term">lessor</ref> must provide a written explanation at that time. If a consumer requests an explanation after consummation, the <ref target="1013-2-h" reftype="term">lessor</ref> must provide a written explanation within a reasonable time after the request is made.</content>
+              </interpParagraph>
+              <interpParagraph label="1013-4-g-1-Interp-4" marker="4.">
+                <title type="keyterm">Default.</title>
+                <content>When default is a condition for early termination of a <ref target="1013-2-e-1" reftype="term">lease</ref>, default charges must be disclosed under § <ref target="1013-4-g-1" reftype="internal">1013.4(g)(1)</ref>. See the commentary to § <ref target="1013-4-q-Interp" reftype="internal">1013.4(q)</ref>.</content>
+              </interpParagraph>
+              <interpParagraph label="1013-4-g-1-Interp-5" marker="5.">
+                <title type="keyterm">Lessee's liability at early termination.</title>
+                <content>When the <ref target="1013-2-g" reftype="term">lessee</ref> is liable for the difference between the unamortized cost and the <ref target="1013-2-m" reftype="term">realized value</ref> at early termination, the method of determining the amount of the difference must be disclosed under § <ref target="1013-4-g-1" reftype="internal">1013.4(g)(1)</ref>.</content>
+              </interpParagraph>
+            </interpParagraph>
+          </interpParagraph>
+          <interpParagraph label="1013-4-h-Interp" target="1013-4-h">
+            <title>4(h) Maintenance Responsibilities</title>
+            <content/>
+            <interpParagraph label="1013-4-h-Interp-1" marker="1.">
+              <title type="keyterm">Standards for wear and use.</title>
+              <content>No disclosure is required if a <ref target="1013-2-h" reftype="term">lessor</ref> does not set standards or impose charges for wear and use (such as excess mileage).</content>
+            </interpParagraph>
+          </interpParagraph>
+          <interpParagraph label="1013-4-i-Interp" target="1013-4-i">
+            <title>4(i) Purchase Option</title>
+            <content/>
+            <interpParagraph label="1013-4-i-Interp-1" marker="1.">
+              <title type="keyterm">Mandatory disclosure of no purchase option.</title>
+              <content>Generally the <ref target="1013-2-h" reftype="term">lessor</ref> need only make the specific required disclosures that apply to a transaction. In the case of a purchase option disclosure, however, a <ref target="1013-2-h" reftype="term">lessor</ref> must disclose affirmatively that the <ref target="1013-2-g" reftype="term">lessee</ref> has no option to purchase the leased property if the purchase option is inapplicable.</content>
+            </interpParagraph>
+            <interpParagraph label="1013-4-i-Interp-2" marker="2.">
+              <title type="keyterm">Existence of purchase option.</title>
+              <content>Whether a purchase option exists under the <ref target="1013-2-e-1" reftype="term">lease</ref> is determined by <ref target="1013-2-p" reftype="term">state</ref> or other applicable law. The <ref target="1013-2-g" reftype="term">lessee</ref>'s right to submit a bid to purchase property at termination of the <ref target="1013-2-e-1" reftype="term">lease</ref> is not an option to purchase under § <ref target="1013-4-i" reftype="internal">1013.4(i)</ref> if the <ref target="1013-2-h" reftype="term">lessor</ref> is not required to accept the <ref target="1013-2-g" reftype="term">lessee</ref>'s bid and the <ref target="1013-2-g" reftype="term">lessee</ref> does not receive preferential treatment.</content>
+            </interpParagraph>
+            <interpParagraph label="1013-4-i-Interp-3" marker="3.">
+              <title type="keyterm">Purchase-option fee.</title>
+              <content>A purchase-option fee is disclosed under § <ref target="1013-4-i" reftype="internal">1013.4(i)</ref>, not § <ref target="1013-4-d" reftype="internal">1013.4(d)</ref>. The fee may be separately itemized or disclosed as part of the purchase-option price.</content>
+            </interpParagraph>
+            <interpParagraph label="1013-4-i-Interp-4" marker="4.">
+              <title type="keyterm">Official fees and taxes.</title>
+              <content>Official fees such as those for taxes, licenses, and registration charged in connection with the exercise of a purchase option may be disclosed under § <ref target="1013-4-i" reftype="internal">1013.4(i)</ref> as part of the purchase-option price (with or without a reference to their inclusion in that price) or may be separately disclosed and itemized by category. Alternatively, a <ref target="1013-2-h" reftype="term">lessor</ref> may provide a statement indicating that the purchase-option price does not include fees for tags, taxes, and registration.</content>
+            </interpParagraph>
+            <interpParagraph label="1013-4-i-Interp-5" marker="5.">
+              <title type="keyterm">Purchase-option price.</title>
+              <content><ref target="1013-2-h" reftype="term">Lessors</ref> must disclose the purchase-option price as a sum certain or as a sum certain to be determined at a future date by reference to a readily available independent source. The reference should provide sufficient information so that the <ref target="1013-2-g" reftype="term">lessee</ref> will be able to determine the actual price when the option becomes available. Statements of a purchase price as the “negotiated price” or the “fair market value” do not comply with the requirements of § <ref target="1013-4-i" reftype="internal">1013.4(i)</ref>.</content>
+            </interpParagraph>
+          </interpParagraph>
+          <interpParagraph label="1013-4-j-Interp" target="1013-4-j">
+            <title>4(j) Statement Referencing Nonsegregated Disclosures</title>
+            <content/>
+            <interpParagraph label="1013-4-j-Interp-1" marker="1.">
+              <title type="keyterm">Content.</title>
+              <content>A <ref target="1013-2-h" reftype="term">lessor</ref> may delete inapplicable items from the disclosure. For example, if a <ref target="1013-2-e-1" reftype="term">lease</ref> contract does not include a <ref target="1013-2-o" reftype="term">security interest</ref>, the reference to a <ref target="1013-2-o" reftype="term">security interest</ref> may be omitted.</content>
+            </interpParagraph>
+          </interpParagraph>
+          <interpParagraph label="1013-4-l-Interp" target="1013-4-l">
+            <title>4(l) Right of Appraisal</title>
+            <content/>
+            <interpParagraph label="1013-4-l-Interp-1" marker="1.">
+              <title type="keyterm">Disclosure inapplicable.</title>
+              <content>The <ref target="1013-2-g" reftype="term">lessee</ref> does not have the right to an independent appraisal merely because the <ref target="1013-2-g" reftype="term">lessee</ref> is liable at the end of the <ref target="1013-2-e-1" reftype="term">lease</ref> term or at early termination for unreasonable wear or use. Thus, the disclosure under § <ref target="1013-4-l" reftype="internal">1013.4(l)</ref> does not apply. For example:</content>
+              <interpParagraph label="1013-4-l-Interp-1-i" marker="i.">
+                <content>The automobile <ref target="1013-2-h" reftype="term">lessor</ref> might expect a <ref target="1013-2-g" reftype="term">lessee</ref> to return an undented car with four good tires at the end of the <ref target="1013-2-e-1" reftype="term">lease</ref> term. Even though it may hold the <ref target="1013-2-g" reftype="term">lessee</ref> liable for the difference between a dented car with bald tires and the value of a car in reasonably good repair, the disclosure under § <ref target="1013-4-l" reftype="internal">1013.4(l)</ref> is not required.</content>
+              </interpParagraph>
+            </interpParagraph>
+            <interpParagraph label="1013-4-l-Interp-2" marker="2.">
+              <title type="keyterm">Lessor's appraisal.</title>
+              <content>If the <ref target="1013-2-h" reftype="term">lessor</ref> obtains an appraisal of the leased property to determine its <ref target="1013-2-m" reftype="term">realized value</ref>, that appraisal does not suffice for purposes of section 183(c) of the <ref target="1013-2-a" reftype="term">Act</ref>; the <ref target="1013-2-h" reftype="term">lessor</ref> must disclose the <ref target="1013-2-g" reftype="term">lessee</ref>'s right to an independent appraisal under § <ref target="1013-4-l" reftype="internal">1013.4(l)</ref>.</content>
+            </interpParagraph>
+            <interpParagraph label="1013-4-l-Interp-3" marker="3.">
+              <title type="keyterm">Retail or wholesale.</title>
+              <content>In providing the disclosures in § <ref target="1013-4-l" reftype="internal">1013.4(l)</ref>, a <ref target="1013-2-h" reftype="term">lessor</ref> must indicate whether the wholesale or retail appraisal value will be used.</content>
+            </interpParagraph>
+            <interpParagraph label="1013-4-l-Interp-4" marker="4.">
+              <title type="keyterm">Time restriction on appraisal.</title>
+              <content>The regulation does not specify a time period in which the <ref target="1013-2-g" reftype="term">lessee</ref> must exercise the appraisal right. The <ref target="1013-2-h" reftype="term">lessor</ref> may require a <ref target="1013-2-g" reftype="term">lessee</ref> to obtain the appraisal within a reasonable time after termination of the <ref target="1013-2-e-1" reftype="term">lease</ref>.</content>
+            </interpParagraph>
+          </interpParagraph>
+          <interpParagraph label="1013-4-m-Interp" target="1013-4-m">
+            <title>4(m) Liability at End of Lease Term Based on Residual Value</title>
+            <content/>
+            <interpParagraph label="1013-4-m-Interp-1" marker="1.">
+              <title type="keyterm">Open-end leases.</title>
+              <content>Section <ref target="1013-4-m" reftype="internal">1013.4(m)</ref> applies only to <ref target="1013-2-i" reftype="term">open-end leases</ref>.</content>
+            </interpParagraph>
+            <interpParagraph label="1013-4-m-Interp-2" marker="2.">
+              <title type="keyterm">Lessor's payment of attorney's fees.</title>
+              <content>Section 183(a) of the <ref target="1013-2-a" reftype="term">Act</ref> requires that the <ref target="1013-2-h" reftype="term">lessor</ref> pay the <ref target="1013-2-g" reftype="term">lessee</ref>'s attorney's fees in all actions under § <ref target="1013-4-m" reftype="internal">1013.4(m)</ref>, whether successful or not.</content>
+            </interpParagraph>
+            <interpParagraph label="1013-4-m-1-Interp" target="1013-4-m-1">
+              <title>4(m)(1) Rent and Other Charges</title>
+              <content/>
+              <interpParagraph label="1013-4-m-1-Interp-1" marker="1.">
+                <title type="keyterm">General.</title>
+                <content>This disclosure is intended to represent the cost of financing an <ref target="1013-2-i" reftype="term">open-end lease</ref> based on charges and fees that the <ref target="1013-2-h" reftype="term">lessor</ref> requires the <ref target="1013-2-g" reftype="term">lessee</ref> to pay. Examples of disclosable charges, in addition to the rent charge, include acquisition, disposition, or assignment fees. Charges imposed by a third party whose services are not required by the <ref target="1013-2-h" reftype="term">lessor</ref> (such as official fees and voluntary insurance) are not included in the § <ref target="1013-4-m-1" reftype="internal">1013.4(m)(1)</ref> disclosure.</content>
+              </interpParagraph>
+            </interpParagraph>
+            <interpParagraph label="1013-4-m-2-Interp" target="1013-4-m-2">
+              <title>4(m)(2) Excess Liability</title>
+              <content/>
+              <interpParagraph label="1013-4-m-2-Interp-1" marker="1.">
+                <title type="keyterm">Coverage.</title>
+                <content>The disclosure limiting the <ref target="1013-2-g" reftype="term">lessee</ref>'s liability for the value of the leased property does not apply in the case of early termination.</content>
+              </interpParagraph>
+              <interpParagraph label="1013-4-m-2-Interp-2" marker="2.">
+                <title type="keyterm">Leases with a minimum term.</title>
+                <content>If a <ref target="1013-2-e-1" reftype="term">lease</ref> has an alternative minimum term, the disclosures governing the liability limitation are not applicable for the minimum term.</content>
+              </interpParagraph>
+              <interpParagraph label="1013-4-m-2-Interp-3" marker="3.">
+                <title type="keyterm">Charges not subject to rebuttable presumption.</title>
+                <content>The limitation on liability applies only to liability at the end of the <ref target="1013-2-e-1" reftype="term">lease</ref> term that is based on the difference between the <ref target="1013-2-n" reftype="term">residual value</ref> of the leased property and its <ref target="1013-2-m" reftype="term">realized value</ref>. The regulation does not preclude a <ref target="1013-2-h" reftype="term">lessor</ref> from recovering other charges from the <ref target="1013-2-g" reftype="term">lessee</ref> at the end of the <ref target="1013-2-e-1" reftype="term">lease</ref> term. Examples of such charges include:</content>
+                <interpParagraph label="1013-4-m-2-Interp-3-i" marker="i.">
+                  <content>Disposition charges.</content>
+                </interpParagraph>
+                <interpParagraph label="1013-4-m-2-Interp-3-ii" marker="ii.">
+                  <content>Excess mileage charges.</content>
+                </interpParagraph>
+                <interpParagraph label="1013-4-m-2-Interp-3-iii" marker="iii.">
+                  <content>Late payment and default charges.</content>
+                </interpParagraph>
+                <interpParagraph label="1013-4-m-2-Interp-3-iv" marker="iv.">
+                  <content>In simple-interest accounting <ref target="1013-2-e-1" reftype="term">leases</ref>, amount by which the unamortized cost exceeds the <ref target="1013-2-n" reftype="term">residual value</ref> because the <ref target="1013-2-g" reftype="term">lessee</ref> has not made timely payments.</content>
+                </interpParagraph>
+              </interpParagraph>
+            </interpParagraph>
+          </interpParagraph>
+          <interpParagraph label="1013-4-n-Interp" target="1013-4-n">
+            <title>4(n) Fees and Taxes</title>
+            <content/>
+            <interpParagraph label="1013-4-n-Interp-1" marker="1.">
+              <title type="keyterm">Treatment of certain taxes.</title>
+              <content>Taxes paid in connection with the <ref target="1013-2-e-1" reftype="term">lease</ref> are generally disclosed under § <ref target="1013-4-n" reftype="internal">1013.4(n)</ref>, but there are exceptions. To illustrate:</content>
+              <interpParagraph label="1013-4-n-Interp-1-i" marker="i.">
+                <content>Taxes paid by <ref target="1013-2-e-1" reftype="term">lease</ref> signing or delivery are disclosed under § <ref target="1013-4-b" reftype="internal">1013.4(b)</ref> and § <ref target="1013-4-n" reftype="internal">1013.4(n)</ref>.</content>
+              </interpParagraph>
+              <interpParagraph label="1013-4-n-Interp-1-ii" marker="ii.">
+                <content>Taxes that are part of the scheduled payments are reflected in the disclosure under § <ref target="1013-4-c" reftype="internal">1013.4(c)</ref>, <ref target="1013-4-f" reftype="internal">(f)</ref>, and <ref target="1013-4-n" reftype="internal">(n)</ref>.</content>
+              </interpParagraph>
+              <interpParagraph label="1013-4-n-Interp-1-iii" marker="iii.">
+                <content>A tax payable by the <ref target="1013-2-h" reftype="term">lessor</ref> that is passed on to the consumer and is reflected in the <ref target="1013-2-e-1" reftype="term">lease</ref> documentation must be disclosed under § <ref target="1013-4-n" reftype="internal">1013.4(n)</ref>. A tax payable by the <ref target="1013-2-h" reftype="term">lessor</ref> and absorbed as a cost of doing business need not be disclosed.</content>
+              </interpParagraph>
+              <interpParagraph label="1013-4-n-Interp-1-iv" marker="iv.">
+                <content>Taxes charged in connection with the exercise of a purchase option are disclosed under § <ref target="1013-4-i" reftype="internal">1013.4(i)</ref>, not § <ref target="1013-4-n" reftype="internal">1013.4(n)</ref>.</content>
+              </interpParagraph>
+            </interpParagraph>
+            <interpParagraph label="1013-4-n-Interp-2" marker="2.">
+              <title type="keyterm">Estimates.</title>
+              <content>In disclosing the total amount of fees and taxes under § <ref target="1013-4-n" reftype="internal">1013.4(n)</ref>, <ref target="1013-2-h" reftype="term">lessors</ref> may need to base the disclosure on estimated tax rates or amounts and are afforded great flexibility in doing so. Where a rate is applied to the future value of leased property, <ref target="1013-2-h" reftype="term">lessors</ref> have flexibility in estimating that value, including, but not limited to, using the mathematical average of the agreed upon value and the <ref target="1013-2-n" reftype="term">residual value</ref> or published valuation guides; or a <ref target="1013-2-h" reftype="term">lessor</ref> could prepare estimates using the agreed upon value and disclose a reasonable estimate of the total fees and taxes. <ref target="1013-2-h" reftype="term">Lessors</ref> may include a statement that the actual total of fees and taxes may be higher or lower depending on the tax rates in effect or the value of the leased property at the time a fee or tax is assessed.</content>
+            </interpParagraph>
+          </interpParagraph>
+          <interpParagraph label="1013-4-o-Interp" target="1013-4-o">
+            <title>4(o) Insurance</title>
+            <content/>
+            <interpParagraph label="1013-4-o-Interp-1" marker="1.">
+              <title type="keyterm">Coverage.</title>
+              <content>If insurance is obtained through the <ref target="1013-2-h" reftype="term">lessor</ref>, information on the type and amount of insurance coverage (whether voluntary or required) as well as the cost, must be disclosed.</content>
+            </interpParagraph>
+            <interpParagraph label="1013-4-o-Interp-2" marker="2.">
+              <title type="keyterm">Lessor's insurance.</title>
+              <content>Insurance purchased by the <ref target="1013-2-h" reftype="term">lessor</ref> primarily for its own benefit, and absorbed as a business expense and not separately charged to the <ref target="1013-2-g" reftype="term">lessee</ref>, need not be disclosed under § <ref target="1013-4-o" reftype="internal">1013.4(o)</ref> even if it provides an incidental benefit to the <ref target="1013-2-g" reftype="term">lessee</ref>.</content>
+            </interpParagraph>
+            <interpParagraph label="1013-4-o-Interp-3" marker="3.">
+              <title type="keyterm">Mechanical breakdown protection and other products.</title>
+              <content>Whether products purchased in conjunction with a <ref target="1013-2-e-1" reftype="term">lease</ref>, such as mechanical breakdown protection (MBP) or guaranteed automobile protection (GAP), should be treated as insurance is determined by <ref target="1013-2-p" reftype="term">state</ref> or other applicable law. In <ref target="1013-2-p" reftype="term">states</ref> that do not treat MBP or GAP as insurance, § <ref target="1013-4-o" reftype="internal">1013.4(o)</ref> disclosures are not required. In such cases the <ref target="1013-2-h" reftype="term">lessor</ref> may, however, disclose this information in accordance with the additional information provision in § <ref target="1013-3-b" reftype="internal">1013.3(b)</ref>. For MBP insurance contracts not capped by a dollar amount, <ref target="1013-2-h" reftype="term">lessors</ref> may describe coverage by referring to a limitation by mileage or time period, for example, by indicating that the mechanical breakdown contract insures parts of the automobile for up to 100,000 miles.</content>
+            </interpParagraph>
+          </interpParagraph>
+          <interpParagraph label="1013-4-p-Interp" target="1013-4-p">
+            <title>4(p) Warranties or Guarantees</title>
+            <content/>
+            <interpParagraph label="1013-4-p-Interp-1" marker="1.">
+              <title type="keyterm">Brief identification.</title>
+              <content>The statement identifying warranties may be brief and need not describe or list all warranties applicable to specific parts such as for air conditioning, radio, or tires in an automobile. For example, manufacturer's warranties may be identified simply by a reference to the standard manufacturer's warranty. If a <ref target="1013-2-h" reftype="term">lessor</ref> provides a comprehensive list of warranties that may not all apply, to comply with § <ref target="1013-4-p" reftype="internal">1013.4(p)</ref> the <ref target="1013-2-h" reftype="term">lessor</ref> must indicate which warranties apply or, alternatively, which warranties do not apply.</content>
+            </interpParagraph>
+            <interpParagraph label="1013-4-p-Interp-2" marker="2.">
+              <title type="keyterm">Warranty disclaimers.</title>
+              <content>Although a disclaimer of warranties is not required by the regulation, the <ref target="1013-2-h" reftype="term">lessor</ref> may give a disclaimer as additional information in accordance with § <ref target="1013-3-b" reftype="internal">1013.3(b)</ref>.</content>
+            </interpParagraph>
+            <interpParagraph label="1013-4-p-Interp-3" marker="3.">
+              <title type="keyterm">State law.</title>
+              <content>Whether an express warranty or guaranty exists is determined by <ref target="1013-2-p" reftype="term">state</ref> or other law.</content>
+            </interpParagraph>
+          </interpParagraph>
+          <interpParagraph label="1013-4-q-Interp" target="1013-4-q">
+            <title>4(q) Penalties and Other Charges for Delinquency</title>
+            <content/>
+            <interpParagraph label="1013-4-q-Interp-1" marker="1.">
+              <title type="keyterm">Collection costs.</title>
+              <content>The automatic imposition of collection costs or attorney fees upon default must be disclosed under § <ref target="1013-4-q" reftype="internal">1013.4(q)</ref>. Collection costs or attorney fees that are not imposed automatically, but are contingent upon expenditures in conjunction with a collection proceeding or upon the employment of an attorney to effect collection, need not be disclosed.</content>
+            </interpParagraph>
+            <interpParagraph label="1013-4-q-Interp-2" marker="2.">
+              <title type="keyterm">Charges for early termination.</title>
+              <content>When default is a condition for early termination of a <ref target="1013-2-e-1" reftype="term">lease</ref>, default charges must also be disclosed under § <ref target="1013-4-g-1" reftype="internal">1013.4(g)(1)</ref>. The § <ref target="1013-4-q" reftype="internal">1013.4(q)</ref> and <ref target="1013-4-g-1" reftype="internal">(g)(1)</ref> disclosures may, but need not, be combined. Examples of combined disclosures are provided in the model <ref target="1013-2-e-1" reftype="term">lease</ref> disclosure forms in Appendix <ref target="1013-A" reftype="internal">A</ref>.</content>
+            </interpParagraph>
+            <interpParagraph label="1013-4-q-Interp-3" marker="3.">
+              <title type="keyterm">Simple-interest leases.</title>
+              <content>In a simple-interest accounting <ref target="1013-2-e-1" reftype="term">lease</ref>, the additional rent charge that accrues on the <ref target="1013-2-e-1" reftype="term">lease</ref> balance when a periodic payment is made after the due date does not constitute a penalty or other charge for late payment. Similarly, continued accrual of the rent charge after termination of the <ref target="1013-2-e-1" reftype="term">lease</ref> because the <ref target="1013-2-g" reftype="term">lessee</ref> fails to return the leased property does not constitute a default charge. But in either case, if the additional charge accrues at a rate higher than the normal rent charge, the <ref target="1013-2-h" reftype="term">lessor</ref> must disclose the amount of or the method of determining the additional charge under § <ref target="1013-4-q" reftype="internal">1013.4(q)</ref>.</content>
+            </interpParagraph>
+            <interpParagraph label="1013-4-q-Interp-4" marker="4.">
+              <title type="keyterm">Extension charges.</title>
+              <content>Extension charges that exceed the rent charge in a simple-interest accounting <ref target="1013-2-e-1" reftype="term">lease</ref> or that are added separately are disclosed under § <ref target="1013-4-q" reftype="internal">1013.4(q)</ref>.</content>
+            </interpParagraph>
+            <interpParagraph label="1013-4-q-Interp-5" marker="5.">
+              <title type="keyterm">Reasonableness of charges.</title>
+              <content>Pursuant to section 183(b) of the <ref target="1013-2-a" reftype="term">Act</ref>, penalties or other charges for delinquency, default, or early termination may be specified in the <ref target="1013-2-e-1" reftype="term">lease</ref> but only in an amount that is reasonable in light of the anticipated or actual harm caused by the delinquency, default, or early termination, the difficulties of proof of loss, and the inconvenience or nonfeasibility of otherwise obtaining an adequate remedy.</content>
+            </interpParagraph>
+          </interpParagraph>
+          <interpParagraph label="1013-4-r-Interp" target="1013-4-r">
+            <title>4(r) Security Interest</title>
+            <content/>
+            <interpParagraph label="1013-4-r-Interp-1" marker="1.">
+              <title type="keyterm">Disclosable security interests.</title>
+              <content>See § <ref target="1013-2-o" reftype="internal">1013.2(o)</ref> and accompanying commentary to determine what <ref target="1013-2-o" reftype="term">security interests</ref> must be disclosed.</content>
+            </interpParagraph>
+          </interpParagraph>
+          <interpParagraph label="1013-4-s-Interp" target="1013-4-s">
+            <title>4(s) Limitations on Rate Information</title>
+            <content/>
+            <interpParagraph label="1013-4-s-Interp-1" marker="1.">
+              <title type="keyterm">Segregated disclosures.</title>
+              <content>A <ref target="1013-2-e-1" reftype="term">lease</ref> rate may not be included among the segregated disclosures referenced in § <ref target="1013-3-a-2" reftype="internal">1013.3(a)(2)</ref>.</content>
+            </interpParagraph>
+          </interpParagraph>
+        </interpSection>
+        <interpSection label="1013-5-Interp" sectionNum="5" target="1013-5">
+          <title>Section 1013.5—Renegotiations, Extensions, and Assumptions</title>
+          <interpParagraph label="1013-5-Interp-1" marker="1.">
+            <title type="keyterm">Coverage.</title>
+            <content>Section <ref target="1013-5" reftype="internal">1013.5</ref> applies only to existing <ref target="1013-2-e-1" reftype="term">leases</ref> that are covered by the regulation. It does not apply to the renegotiation or extension of <ref target="1013-2-e-1" reftype="term">leases</ref> with an initial term of four months or less, because such <ref target="1013-2-e-1" reftype="term">leases</ref> are not covered by the definition of <ref target="1013-2-e-1" reftype="term">consumer lease</ref> in § <ref target="1013-2-e" reftype="internal">1013.2(e)</ref>. Whether and when a <ref target="1013-2-e-1" reftype="term">lease</ref> is satisfied and replaced by a new <ref target="1013-2-e-1" reftype="term">lease</ref> is determined by <ref target="1013-2-p" reftype="term">state</ref> or other applicable law.</content>
+          </interpParagraph>
+          <interpParagraph label="1013-5-a-Interp" target="1013-5-a">
+            <title>5(a) Renegotiation</title>
+            <content/>
+            <interpParagraph label="1013-5-a-Interp-1" marker="1.">
+              <title type="keyterm">Basis of disclosures.</title>
+              <content><ref target="1013-2-h" reftype="term">Lessors</ref> have flexibility in making disclosures so long as they reflect the legal obligation under the renegotiated <ref target="1013-2-e-1" reftype="term">lease</ref>. For example, assume that a 24-month <ref target="1013-2-e-1" reftype="term">lease</ref> is replaced by a 36-month <ref target="1013-2-e-1" reftype="term">lease</ref>. The initial <ref target="1013-2-e-1" reftype="term">lease</ref> began on January 1, 1998, and was renegotiated and replaced on July 1, 1998, so that the new <ref target="1013-2-e-1" reftype="term">lease</ref> term ends on January 1, 2001.</content>
+              <interpParagraph label="1013-5-a-Interp-1-i" marker="i.">
+                <content>If the renegotiated <ref target="1013-2-e-1" reftype="term">lease</ref> covers the 36-month period beginning January 1, 1998, the new disclosures would reflect all payments made by the <ref target="1013-2-g" reftype="term">lessee</ref> on the initial <ref target="1013-2-e-1" reftype="term">lease</ref> and all payments on the renegotiated <ref target="1013-2-e-1" reftype="term">lease</ref>. In this example, since the renegotiated <ref target="1013-2-e-1" reftype="term">lease</ref> covers a 36-month period beginning January 1, 1998, the disclosures must reflect payments made since that date. On the model form, the “total of base periodic payments” disclosed under § <ref target="1013-4-f-7" reftype="internal">1013.4(f)(7)</ref> should reflect periodic payments to be made over the entire 36-month term. Payments received since January 1, 1998, are added as a new line item disclosed as “total of payments received” and are subtracted from the “total of base periodic payments” in calculating a new item disclosed as the “total of base periodic payments remaining.” For example, if 6 monthly payments of $300 were received since January 1, 1998, the disclosure form should include a “total of base periodic payments” line from which $1,800 is subtracted to arrive at the “total of base periodic payments remaining.” The remainder of the disclosures would not change.</content>
+              </interpParagraph>
+              <interpParagraph label="1013-5-a-Interp-1-ii" marker="ii.">
+                <content>If the renegotiated <ref target="1013-2-e-1" reftype="term">lease</ref> covers only the remaining 30 months, from July 1, 1998, to January 1, 2001, the disclosures would reflect only the charges incurred in connection with the renegotiation and the payments for the remaining period.</content>
+              </interpParagraph>
+            </interpParagraph>
+          </interpParagraph>
+          <interpParagraph label="1013-5-b-Interp" target="1013-5-b">
+            <title>5(b) Extension</title>
+            <content/>
+            <interpParagraph label="1013-5-b-Interp-1" marker="1.">
+              <title type="keyterm">Time of extension disclosures.</title>
+              <content>If a <ref target="1013-2-e-1" reftype="term">consumer lease</ref> is extended for a specified term greater than six months, new disclosures are required at the time the extension is agreed upon. If the <ref target="1013-2-e-1" reftype="term">lease</ref> is extended on a month-to-month basis and the cumulative extensions exceed six months, new disclosures are required at the commencement of the seventh month and at the commencement of each seventh month thereafter for as long as the extensions continue. If a <ref target="1013-2-e-1" reftype="term">consumer lease</ref> is extended for terms of varying durations, one of which will exceed six months beyond the originally scheduled termination date of the <ref target="1013-2-e-1" reftype="term">lease</ref>, new disclosures are required at the commencement of the term that will exceed six months beyond the originally scheduled termination date.</content>
+            </interpParagraph>
+            <interpParagraph label="1013-5-b-Interp-2" marker="2.">
+              <title type="keyterm">Content of disclosures for month-to-month extensions.</title>
+              <content>The disclosures for a <ref target="1013-2-e-1" reftype="term">lease</ref> extended on a month-to-month basis for more than six months should reflect the month-to-month nature of the transaction.</content>
+            </interpParagraph>
+            <interpParagraph label="1013-5-b-Interp-3" marker="3.">
+              <title type="keyterm">Basis of disclosures.</title>
+              <content>The disclosures should be based on the extension period, including any upfront costs paid in connection with the extension. For example, assume that initially a <ref target="1013-2-e-1" reftype="term">lease</ref> ends on March 1, 1999. In January 1999, agreement is reached to extend the <ref target="1013-2-e-1" reftype="term">lease</ref> until October 1, 1999. The disclosure would include any extension fee paid in January and the periodic payments for the seven-month extension period beginning in March.</content>
+            </interpParagraph>
+          </interpParagraph>
+        </interpSection>
+        <interpSection label="1013-6-Interp" sectionNum="6">
+          <title>Section 1013.6 [Reserved]</title>
+          <reserved/>
+        </interpSection>
+        <interpSection label="1013-7-Interp" sectionNum="7">
+          <title>Section 1013.7—Advertising</title>
+          <interpParagraph label="1013-7-a-Interp" target="1013-7-a">
+            <title>7(a) General Rule</title>
+            <content/>
+            <interpParagraph label="1013-7-a-Interp-1" marker="1.">
+              <title type="keyterm">Persons covered.</title>
+              <content>All “<ref target="1013-2-k" reftype="term">persons</ref>” must comply with the advertising provisions in this section, not just those that meet the definition of a <ref target="1013-2-h" reftype="term">lessor</ref> in § <ref target="1013-2-h" reftype="internal">1013.2(h)</ref>. Thus, automobile dealers (to the extent they are not excluded from the <ref target="1013-2-c" reftype="term">Bureau</ref>'s rulemaking authority by section 1029 of the Dodd-Frank Act), merchants, and others who are not themselves <ref target="1013-2-h" reftype="term">lessors</ref> must comply with the advertising provisions of the regulation if they advertise <ref target="1013-2-e-1" reftype="term">consumer lease</ref> transactions. Pursuant to section 184(b) of the <ref target="1013-2-a" reftype="term">Act</ref>, however, owners and personnel of the media in which an <ref target="1013-2-b" reftype="term">advertisement</ref> appears or through which it is disseminated are not subject to civil liability for violations under section 185(b) of the <ref target="1013-2-a" reftype="term">Act</ref>.</content>
+            </interpParagraph>
+            <interpParagraph label="1013-7-a-Interp-2" marker="2.">
+              <title type="keyterm">“Usually and customarily.”</title>
+              <content>Section <ref target="1013-7-a" reftype="internal">1013.7(a)</ref> does not prohibit the advertising of a single item or the promotion of a new leasing program, but prohibits the advertising of terms that are not and will not be available. Thus, an <ref target="1013-2-b" reftype="term">advertisement</ref> may state terms that will be offered for only a limited period or terms that will become available at a future date.</content>
+            </interpParagraph>
+            <interpParagraph label="1013-7-a-Interp-3" marker="3.">
+              <title type="keyterm">Total contractual obligation of advertised lease.</title>
+              <content>Section <ref target="1013-7" reftype="internal">1013.7</ref> applies to <ref target="1013-2-b" reftype="term">advertisements</ref> for <ref target="1013-2-e-1" reftype="term">consumer leases</ref>, as defined in § <ref target="1013-2-e" reftype="internal">1013.2(e)</ref>. Under § <ref target="1013-2-e" reftype="internal">1013.2(e)</ref>, a <ref target="1013-2-e-1" reftype="term">consumer lease</ref> is exempt from the requirements of this part if the total contractual obligation exceeds the threshold amount in effect at the time of consummation. See comment <ref target="1013-2-e-Interp-9" reftype="internal">2(e)-9</ref>. Accordingly, § <ref target="1013-7" reftype="internal">1013.7</ref> does not apply to an <ref target="1013-2-b" reftype="term">advertisement</ref> for a specific <ref target="1013-2-e-1" reftype="term">consumer lease</ref> if the total contractual obligation for that <ref target="1013-2-e-1" reftype="term">lease</ref> exceeds the threshold amount in effect when the <ref target="1013-2-b" reftype="term">advertisement</ref> is made. If a <ref target="1013-2-h" reftype="term">lessor</ref> promotes multiple <ref target="1013-2-e-1" reftype="term">consumer leases</ref> in a single <ref target="1013-2-b" reftype="term">advertisement</ref>, the entire <ref target="1013-2-b" reftype="term">advertisement</ref> must comply with § <ref target="1013-7" reftype="internal">1013.7</ref> unless all of the advertised <ref target="1013-2-e-1" reftype="term">leases</ref> are exempt under § <ref target="1013-2-e" reftype="internal">1013.2(e)</ref>. For example:</content>
+              <interpParagraph label="1013-7-a-Interp-3-i" marker="i.">
+                <content>Assume that, in an <ref target="1013-2-b" reftype="term">advertisement</ref>, a <ref target="1013-2-h" reftype="term">lessor</ref> states that certain terms apply to a <ref target="1013-2-e-1" reftype="term">consumer lease</ref> for a specific automobile. The total contractual obligation of the advertised <ref target="1013-2-e-1" reftype="term">lease</ref> exceeds the threshold amount in effect when the <ref target="1013-2-b" reftype="term">advertisement</ref> is made. Although the <ref target="1013-2-b" reftype="term">advertisement</ref> does not refer to any other <ref target="1013-2-e-1" reftype="term">lease</ref>, some or all of the advertised terms for the exempt <ref target="1013-2-e-1" reftype="term">lease</ref> also apply to other <ref target="1013-2-e-1" reftype="term">leases</ref> offered by the <ref target="1013-2-h" reftype="term">lessor</ref> with total contractual obligations that do not exceed the applicable threshold amount. The <ref target="1013-2-b" reftype="term">advertisement</ref> is not required to comply with § <ref target="1013-7" reftype="internal">1013.7</ref> because it refers only to an exempt <ref target="1013-2-e-1" reftype="term">lease</ref>.</content>
+              </interpParagraph>
+              <interpParagraph label="1013-7-a-Interp-3-ii" marker="ii.">
+                <content>Assume that, in an <ref target="1013-2-b" reftype="term">advertisement</ref>, a <ref target="1013-2-h" reftype="term">lessor</ref> states certain terms (such as the amount due at <ref target="1013-2-e-1" reftype="term">lease</ref> signing) that will apply to <ref target="1013-2-e-1" reftype="term">consumer leases</ref> for automobiles of a particular brand. However, the <ref target="1013-2-b" reftype="term">advertisement</ref> does not refer to a specific <ref target="1013-2-e-1" reftype="term">lease</ref>. The total contractual obligations of the <ref target="1013-2-e-1" reftype="term">leases</ref> for some of the automobiles will exceed the threshold amount in effect when the <ref target="1013-2-b" reftype="term">advertisement</ref> is made, but the total contractual obligations of the <ref target="1013-2-e-1" reftype="term">leases</ref> for other automobiles will not exceed the threshold. The entire <ref target="1013-2-b" reftype="term">advertisement</ref> must comply with § <ref target="1013-7" reftype="internal">1013.7</ref> because it refers to terms for <ref target="1013-2-e-1" reftype="term">consumer leases</ref> that are not exempt.</content>
+              </interpParagraph>
+              <interpParagraph label="1013-7-a-Interp-3-iii" marker="iii.">
+                <content>Assume that, in a single <ref target="1013-2-b" reftype="term">advertisement</ref>, a <ref target="1013-2-h" reftype="term">lessor</ref> states that certain terms apply to <ref target="1013-2-e-1" reftype="term">consumer leases</ref> for two different automobiles. The total contractual obligation of the <ref target="1013-2-e-1" reftype="term">lease</ref> for the first automobile exceeds the threshold amount in effect when the <ref target="1013-2-b" reftype="term">advertisement</ref> is made, but the total contractual obligation of the <ref target="1013-2-e-1" reftype="term">lease</ref> for the second automobile does not exceed the threshold. The entire <ref target="1013-2-b" reftype="term">advertisement</ref> must comply with § <ref target="1013-7" reftype="internal">1013.7</ref> because it refers to a <ref target="1013-2-e-1" reftype="term">consumer lease</ref> that is not exempt.</content>
+              </interpParagraph>
+            </interpParagraph>
+          </interpParagraph>
+          <interpParagraph label="1013-7-b-Interp" target="1013-7-b">
+            <title>7(b) Clear and Conspicuous Standard</title>
+            <content/>
+            <interpParagraph label="1013-7-b-Interp-1" marker="1.">
+              <title type="keyterm">Standard.</title>
+              <content>The disclosures in an <ref target="1013-2-b" reftype="term">advertisement</ref> in any media must be reasonably understandable. For example, very fine print in a television <ref target="1013-2-b" reftype="term">advertisement</ref> or detailed and very rapidly stated information in a radio <ref target="1013-2-b" reftype="term">advertisement</ref> does not meet the clear and conspicuous standard if consumers cannot see and read or hear, and cannot comprehend, the information required to be disclosed.</content>
+            </interpParagraph>
+            <interpParagraph label="1013-7-b-1-Interp" target="1013-7-b-1">
+              <title>7(b)(1) Amount Due at Lease Signing or Delivery</title>
+              <content/>
+              <interpParagraph label="1013-7-b-1-Interp-1" marker="1.">
+                <title type="keyterm">Itemization not required.</title>
+                <content>Only a total of amounts due at <ref target="1013-2-e-1" reftype="term">lease</ref> signing or delivery is required to be disclosed, not an itemization of its component parts. Such an itemization is provided in any transaction-specific disclosures provided under § <ref target="1013-4" reftype="internal">1013.4</ref>.</content>
+              </interpParagraph>
+              <interpParagraph label="1013-7-b-1-Interp-2" marker="2.">
+                <title type="keyterm">Prominence rule.</title>
+                <content>Except for a periodic payment, oral or written references to components of the total due at <ref target="1013-2-e-1" reftype="term">lease</ref> signing or delivery (for example, a reference to a capitalized cost reduction, where permitted) may not be more prominent than the disclosure of the total amount due at <ref target="1013-2-e-1" reftype="term">lease</ref> signing or delivery.</content>
+              </interpParagraph>
+            </interpParagraph>
+            <interpParagraph label="1013-7-b-2-Interp" target="1013-7-b-2">
+              <title>7(b)(2) Advertisement of a Lease Rate</title>
+              <content/>
+              <interpParagraph label="1013-7-b-2-Interp-1" marker="1.">
+                <title type="keyterm">Location of statement.</title>
+                <content>The notice required to accompany a percentage rate stated in an <ref target="1013-2-b" reftype="term">advertisement</ref> must be placed in close proximity to the rate without any other intervening language or symbols. For example, a <ref target="1013-2-h" reftype="term">lessor</ref> may not place an asterisk next to the rate and place the notice elsewhere in the <ref target="1013-2-b" reftype="term">advertisement</ref>. In addition, with the exception of the notice required by § <ref target="1013-4-s" reftype="internal">1013.4(s)</ref>, the rate cannot be more prominent than any other § <ref target="1013-4" reftype="internal">1013.4</ref> disclosure stated in the <ref target="1013-2-b" reftype="term">advertisement</ref>.</content>
+              </interpParagraph>
+            </interpParagraph>
+          </interpParagraph>
+          <interpParagraph label="1013-7-c-Interp" target="1013-7-c">
+            <title>7(c) Catalogs or Other Multi-Page Advertisements; Electronic Advertisements</title>
+            <content/>
+            <interpParagraph label="1013-7-c-Interp-1" marker="1.">
+              <title type="keyterm">General rule.</title>
+              <content>The multiple-page <ref target="1013-2-b" reftype="term">advertisements</ref> referred to in § <ref target="1013-7-c" reftype="internal">1013.7(c)</ref> are <ref target="1013-2-b" reftype="term">advertisements</ref> consisting of a series of numbered pages—for example, a supplement to a newspaper. A mailing comprising several separate flyers or pieces of promotional material in a single envelope is not a single multiple-page <ref target="1013-2-b" reftype="term">advertisement</ref>.</content>
+            </interpParagraph>
+            <interpParagraph label="1013-7-c-Interp-2" marker="2.">
+              <title type="keyterm">Cross references.</title>
+              <content>A catalog or other multiple-page <ref target="1013-2-b" reftype="term">advertisement</ref> or an electronic <ref target="1013-2-b" reftype="term">advertisement</ref> (such as an <ref target="1013-2-b" reftype="term">advertisement</ref> appearing on an internet Web site) is a single <ref target="1013-2-b" reftype="term">advertisement</ref> (requiring only one set of <ref target="1013-2-e-1" reftype="term">lease</ref> disclosures) if it contains a table, chart, or schedule with the disclosures required under § <ref target="1013-7-d-2-i" reftype="internal">1013.7(d)(2)(i)</ref> through (v). If one of the triggering terms listed in § <ref target="1013-7-d-1" reftype="internal">1013.7(d)(1)</ref> appears in a catalog, or in a multiple-page or electronic <ref target="1013-2-b" reftype="term">advertisement</ref>, it must clearly direct the consumer to the page or location where the table, chart, or schedule begins. For example, in an electronic <ref target="1013-2-b" reftype="term">advertisement</ref>, a term triggering additional disclosures may be accompanied by a link that directly connects the consumer to the additional information.</content>
+            </interpParagraph>
+          </interpParagraph>
+          <interpParagraph label="1013-7-d-Interp">
+            <content/>
+            <interpParagraph label="1013-7-d-1-Interp" target="1013-7-d-1">
+              <title>7(d)(1) Triggering Terms</title>
+              <content/>
+              <interpParagraph label="1013-7-d-1-Interp-1" marker="1.">
+                <title type="keyterm">Typical example.</title>
+                <content>When any triggering term appears in a <ref target="1013-2-e-1" reftype="term">lease</ref> <ref target="1013-2-b" reftype="term">advertisement</ref>, the additional terms enumerated in § <ref target="1013-7-d-2-i" reftype="internal">1013.7(d)(2)(i)</ref> through (v) must also appear. In a multi-<ref target="1013-2-e-1" reftype="term">lease</ref> <ref target="1013-2-b" reftype="term">advertisement</ref>, an example of one or more typical <ref target="1013-2-e-1" reftype="term">leases</ref> with a statement of all the terms applicable to each may be used. The examples must be labeled as such and must reflect representative <ref target="1013-2-e-1" reftype="term">lease</ref> terms that are made available by the <ref target="1013-2-h" reftype="term">lessor</ref> to consumers.</content>
+              </interpParagraph>
+            </interpParagraph>
+            <interpParagraph label="1013-7-d-2-Interp" target="1013-7-d-2">
+              <title>7(d)(2) Additional Terms</title>
+              <content/>
+              <interpParagraph label="1013-7-d-2-Interp-1" marker="1.">
+                <title type="keyterm">Third-party fees that vary by state or locality.</title>
+                <content>The disclosure of a periodic payment or total amount due at <ref target="1013-2-e-1" reftype="term">lease</ref> signing or delivery may:</content>
+                <interpParagraph label="1013-7-d-2-Interp-1-i" marker="i.">
+                  <content>Exclude third-party fees, such as taxes, licenses, and registration fees and disclose that fact; or</content>
+                </interpParagraph>
+                <interpParagraph label="1013-7-d-2-Interp-1-ii" marker="ii.">
+                  <content>Provide a periodic payment or total that includes third-party fees based on a particular <ref target="1013-2-p" reftype="term">state</ref> or locality as long as that fact and the fact that fees may vary by <ref target="1013-2-p" reftype="term">state</ref> or locality are disclosed.</content>
+                </interpParagraph>
+              </interpParagraph>
+            </interpParagraph>
+          </interpParagraph>
+          <interpParagraph label="1013-7-e-Interp" target="1013-7-e">
+            <title>7(e) Alternative Disclosures—Merchandise Tags</title>
+            <content/>
+            <interpParagraph label="1013-7-e-Interp-1" marker="1.">
+              <title type="keyterm">Multiple-item leases.</title>
+              <content>Multiple-item <ref target="1013-2-e-1" reftype="term">leases</ref> that utilize merchandise tags requiring additional disclosures may use the alternate disclosure rule.</content>
+            </interpParagraph>
+          </interpParagraph>
+          <interpParagraph label="1013-7-f-Interp">
+            <title>7(f) Alternative Disclosures—Television or Radio Advertisements</title>
+            <content/>
+            <interpParagraph label="1013-7-f-1-Interp" target="1013-7-f-1">
+              <title>7(f)(1) Toll-Free Number or Print Advertisement</title>
+              <content/>
+              <interpParagraph label="1013-7-f-1-Interp-1" marker="1.">
+                <title type="keyterm">Publication in general circulation.</title>
+                <content>A reference to a written <ref target="1013-2-b" reftype="term">advertisement</ref> appearing in a newspaper circulated nationally, for example, USA Today or the Wall Street Journal, may satisfy the general circulation requirement in § <ref target="1013-7-f-1-ii" reftype="internal">1013.7(f)(1)(ii)</ref>.</content>
+              </interpParagraph>
+              <interpParagraph label="1013-7-f-1-Interp-2" marker="2.">
+                <title type="keyterm">Toll-free number, local or collect calls.</title>
+                <content>In complying with the disclosure requirements of § <ref target="1013-7-f-1-i" reftype="internal">1013.7(f)(1)(i)</ref>, a <ref target="1013-2-h" reftype="term">lessor</ref> must provide a toll-free number for nonlocal calls made from an area code other than the one used in the <ref target="1013-2-h" reftype="term">lessor</ref>'s dialing area. Alternatively, a <ref target="1013-2-h" reftype="term">lessor</ref> may provide any telephone number that allows a consumer to reverse the phone charges when calling for information.</content>
+              </interpParagraph>
+              <interpParagraph label="1013-7-f-1-Interp-3" marker="3.">
+                <title type="keyterm">Multi-purpose number.</title>
+                <content>When an advertised toll-free number responds with a recording, <ref target="1013-2-e-1" reftype="term">lease</ref> disclosures must be provided early in the sequence to ensure that the consumer receives the required disclosures. For example, in providing several dialing options—such as providing directions to the <ref target="1013-2-h" reftype="term">lessor</ref>'s place of business—the option allowing the consumer to request <ref target="1013-2-e-1" reftype="term">lease</ref> disclosures should be provided early in the telephone message to ensure that the option to request disclosures is not obscured by other information.</content>
+              </interpParagraph>
+              <interpParagraph label="1013-7-f-1-Interp-4" marker="4.">
+                <title type="keyterm">Statement accompanying toll free number.</title>
+                <content>Language must accompany a telephone and television number indicating that disclosures are available by calling the toll-free number, such as “call 1-(800) 000-0000 for details about costs and terms.”</content>
+              </interpParagraph>
+            </interpParagraph>
+          </interpParagraph>
+        </interpSection>
+        <interpSection label="1013-8-Interp" sectionNum="8" target="1013-8">
+          <title>Section 1013.8—Record Retention</title>
+          <interpParagraph label="1013-8-Interp-1" marker="1.">
+            <title type="keyterm">Manner of retaining evidence.</title>
+            <content>A <ref target="1013-2-h" reftype="term">lessor</ref> must retain evidence of having performed required actions and of having made required disclosures. Such records may be retained in paper form, on microfilm, microfiche, or computer, or by any other method designed to reproduce records accurately. The <ref target="1013-2-h" reftype="term">lessor</ref> need retain only enough information to reconstruct the required disclosures or other records.</content>
+          </interpParagraph>
+        </interpSection>
+        <interpSection label="1013-9-Interp" sectionNum="9" target="1013-9">
+          <title>Section 1013.9—Relation to State Laws</title>
+          <interpParagraph label="1013-9-Interp-1" marker="1.">
+            <title type="keyterm">Exemptions granted.</title>
+            <content>The <ref target="1013-2-c" reftype="term">Bureau</ref> recognizes exemptions granted by the Board of Governors of the Federal Reserve System prior to July 21, 2011, until and unless the <ref target="1013-2-c" reftype="term">Bureau</ref> makes and publishes any contrary determination. Effective October 1, 1982, the Board of Governors of the Federal Reserve System granted the following exemptions from portions of the Consumer Leasing Act:</content>
+            <interpParagraph label="1013-9-Interp-1-i" marker="i.">
+              <title type="keyterm">Maine.</title>
+              <content>Lease transactions subject to the Maine Consumer Credit Code and its implementing regulations are exempt from Chapters 2, 4, and 5 of the Federal act. (The exemption does not apply to transactions in which a federally chartered institution is a <ref target="1013-2-h" reftype="term">lessor</ref>.)</content>
+            </interpParagraph>
+            <interpParagraph label="1013-9-Interp-1-ii" marker="ii.">
+              <title type="keyterm">Oklahoma.</title>
+              <content>Lease transactions subject to the Oklahoma Consumer Credit Code are exempt from Chapters 2 and 5 of the Federal act. (The exemption does not apply to sections 132 through 135 of the Federal act, nor does it apply to transactions in which a federally chartered institution is a <ref target="1013-2-h" reftype="term">lessor</ref>.)</content>
+            </interpParagraph>
+          </interpParagraph>
+        </interpSection>
+        <interpSection label="1013-A-Interp" target="1013-A">
+          <title>Appendix A—Model Forms</title>
+          <interpParagraph label="1013-A-Interp-1" marker="1.">
+            <title type="keyterm">Permissible changes.</title>
+            <content>Although use of the model forms is not required, <ref target="1013-2-h" reftype="term">lessors</ref> using them properly will be deemed to be in compliance with the regulation. Generally, <ref target="1013-2-h" reftype="term">lessors</ref> may make certain changes in the format or content of the forms and may delete any disclosures that are inapplicable to a transaction without losing the <ref target="1013-2-a" reftype="term">Act</ref>'s protection from liability. For example, the model form based on monthly periodic payments may be modified for single-payment <ref target="1013-2-e-1" reftype="term">lease</ref> transactions or for quarterly or other regular or irregular periodic payments. The model form may also be modified to reflect that a transaction is an extension. The content, format, and headings for the segregated disclosures must be substantially similar to those contained in the model forms; therefore, any changes should be minimal. The changes to the model forms should not be so extensive as to affect the substance and the clarity of the disclosures.</content>
+          </interpParagraph>
+          <interpParagraph label="1013-A-Interp-2" marker="2.">
+            <title type="keyterm">Examples of acceptable changes.</title>
+            <content/>
+            <interpParagraph label="1013-A-Interp-2-i" marker="i.">
+              <content>Using the first person, instead of the second person, in referring to the <ref target="1013-2-g" reftype="term">lessee</ref>.</content>
+            </interpParagraph>
+            <interpParagraph label="1013-A-Interp-2-ii" marker="ii.">
+              <content>Using “<ref target="1013-2-g" reftype="term">lessee</ref>,” “<ref target="1013-2-h" reftype="term">lessor</ref>,” or names instead of pronouns.</content>
+            </interpParagraph>
+            <interpParagraph label="1013-A-Interp-2-iii" marker="iii.">
+              <content>Rearranging the sequence of the nonsegregated disclosures.</content>
+            </interpParagraph>
+            <interpParagraph label="1013-A-Interp-2-iv" marker="iv.">
+              <content>Incorporating certain <ref target="1013-2-p" reftype="term">state</ref> “plain English” requirements.</content>
+            </interpParagraph>
+            <interpParagraph label="1013-A-Interp-2-v" marker="v.">
+              <content>Deleting or blocking out inapplicable disclosures, filling in “N/A” (not applicable) or “0,” crossing out, leaving blanks, checking a box for applicable items, or circling applicable items (this should facilitate use of multipurpose standard forms).</content>
+            </interpParagraph>
+            <interpParagraph label="1013-A-Interp-2-vi" marker="vi.">
+              <content>Adding language or symbols to indicate estimates.</content>
+            </interpParagraph>
+            <interpParagraph label="1013-A-Interp-2-vii" marker="vii.">
+              <content>Adding numeric or alphabetic designations.</content>
+            </interpParagraph>
+            <interpParagraph label="1013-A-Interp-2-viii" marker="viii.">
+              <content>Rearranging the disclosures into vertical columns, except for § <ref target="1013-4-b" reftype="internal">1013.4(b)</ref> through <ref target="1013-4-e" reftype="internal">(e)</ref> disclosures.</content>
+            </interpParagraph>
+            <interpParagraph label="1013-A-Interp-2-ix" marker="ix.">
+              <content>Using icons and other graphics.</content>
+            </interpParagraph>
+          </interpParagraph>
+          <interpParagraph label="1013-A-Interp-3" marker="3.">
+            <title type="keyterm">Model closed-end or net vehicle lease disclosure.</title>
+            <content>Model <ref target="1013-A-2" reftype="internal">A-2</ref> is designed for a closed-end or net vehicle <ref target="1013-2-e-1" reftype="term">lease</ref>. Under the “Early Termination and Default” provision a reference to the <ref target="1013-2-g" reftype="term">lessee</ref>'s right to an independent appraisal of the leased vehicle under § <ref target="1013-4-l" reftype="internal">1013.4(l)</ref> is included for those <ref target="1013-2-d" reftype="term">closed-end leases</ref> in which the <ref target="1013-2-g" reftype="term">lessee</ref>'s liability at early termination is based on the vehicle's <ref target="1013-2-m" reftype="term">realized value</ref>.</content>
+          </interpParagraph>
+          <interpParagraph label="1013-A-Interp-4" marker="4.">
+            <title type="keyterm">Model furniture lease disclosures.</title>
+            <content>Model <ref target="1013-A-3" reftype="internal">A-3</ref> is a <ref target="1013-2-d" reftype="term">closed-end lease</ref> disclosure statement designed for a typical furniture <ref target="1013-2-e-1" reftype="term">lease</ref>. It does not include a disclosure of the appraisal right at early termination required under § <ref target="1013-4-l" reftype="internal">1013.4(l)</ref> because few closed-end furniture <ref target="1013-2-e-1" reftype="term">leases</ref> base the <ref target="1013-2-g" reftype="term">lessee</ref>'s liability at early termination on the <ref target="1013-2-m" reftype="term">realized value</ref> of the leased property. The disclosure should be added if it is applicable.</content>
+          </interpParagraph>
+        </interpSection>
+      </interpretations>
+    </content>
+  </part>
+</regulation>


### PR DESCRIPTION
Source notice:

https://www.federalregister.gov/documents/2017/11/09/2017-24411/consumer-leasing-regulation-m

This notice takes effect on 2018-01-01 and applies to 2017-24411.

Files created manually via inspection of the source notice. Both files validate using the validator in
https://github.com/cfpb/regulations-xml-parser using command line:

$ regml.py validate notice/1013/2017-24411.xml
$ regml.py validate regulation/1013/2017-24411.xml